### PR TITLE
Remove GitHub sponsor and update Repository URL's 

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [dermatz]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## UNRELEASED 0.1.0
+## 0.1.0
 
 - added trunk support
 - added GitHub `issue` and `feature` templates
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - added dependabot
 - added `VersionCommand`
 - added Codacy Badge to `README.md`
+- changed Repository URLs
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We appreciate your interest in contributing to MageForge! Please follow the guid
 
 ## Submitting a Pull Request
 
-1. **Create an Issue**: Start by [creating an issue](https://github.com/dermatz/mageforge/issues) to describe your feature request or bug report. Be sure to include all relevant details.
+1. **Create an Issue**: Start by [creating an issue](https://github.com/OpenForgeProject/mageforge/issues) to describe your feature request or bug report. Be sure to include all relevant details.
 2. **Fork the Repository**: Fork this repository and create a new branch for your work that corresponds to the issue you opened.
 3. **Commit Your Changes**: Make your changes in the new branch and commit them with clear, descriptive messages.
 4. **Open a Pull Request**: Submit a pull request to merge your changes into the `main` branch of this repository.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # MageForge for Magento 2
 
 ![Mageforge Hero](./.github/assets/mageforge-hero.jpg)
-
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/365d32460022451ba3918f5643341753)](https://app.codacy.com/gh/dermatz/mageforge/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/7d7c46d7492043c7ada514ed1d4a4c05)](https://app.codacy.com/gh/OpenForgeProject/mageforge/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 MageForge is a Magento 2 module designed to assist frontend developers in streamlining their workflow and enhancing productivity.
 
 ---
 
-[![Join our Discord community](./.github/assets/small_logo_blurple_RGB.png)](https://discord.gg/H5CjMXQQHn)
+[![Join our OpenForgeProject Discord community](./.github/assets/small_logo_blurple_RGB.png)](https://discord.gg/H5CjMXQQHn)
 
 ## Features
 
@@ -38,7 +37,7 @@ Latest Version: 1.0.0
 ## Report Feature or Bugs
 
 MageForge provides several forms to submit feature requests or report a bug.
-You will find it in the [issue section](https://github.com/dermatz/mageforge/issues) of GitHub.
+You will find it in the [issue section](https://github.com/OpenForgeProject/mageforge/issues) of GitHub.
 
 ## Contributing
 
@@ -56,7 +55,7 @@ See the [LICENSE](LICENSE) file for more details.
 
 ## Support
 
-For support, please open an issue on the [GitHub repository](https://github.com/dermatz/mageforge/issues).
+For support, please open an issue on the [GitHub repository](https://github.com/OpenForgeProject/mageforge/issues).
 
 ## Changelog
 


### PR DESCRIPTION
Remove GitHub sponsor and update references to `OpenForgeProject`.

* **README.md**
  - Update Codacy Badge link to reference `OpenForgeProject`.
  - Update issue section link to reference `OpenForgeProject/mageforge`.
  - Update support section link to reference `OpenForgeProject/mageforge`.

* **CONTRIBUTING.md**
  - Update issue section link to reference `OpenForgeProject/mageforge`.

* **.github/FUNDING.yml**
  - Delete the file.

