### PR TITLE
Rename module and update API URL to reflect new namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## 0.1.0
+## UNRELEASED
 
 - added trunk support
 - added GitHub `issue` and `feature` templates
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - added Codacy Badge to `README.md`
 - changed Repository URLs
 - added codacy code-quality badge to `README.md`
+- moved to OpenForgeProject
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mageforge/base",
+  "name": "openforgeproject/mageforge",
   "description": "Magento 2 module for frontend wizardry~",
   "license": "GPL-3.0",
   "type": "magento2-module",
@@ -8,7 +8,7 @@
       "registration.php"
     ],
     "psr-4": {
-      "MageForge\\Base\\": "src/"
+      "OpenForgeProject\\MageForge\\": "src/"
     }
   }
 }

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -14,7 +14,7 @@ use Magento\Framework\Filesystem\Driver\File;
 
 class VersionCommand extends Command
 {
-    private const API_URL = 'https://api.github.com/repos/mage-forge/base/releases/latest';
+    private const API_URL = 'https://api.github.com/repos/openforgeproject/mageforge/releases/latest';
     private const UNKNOWN_VERSION = 'Unknown';
 
     /**

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -3,5 +3,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd"
 >
-    <module name="MageForge_Base" />
+    <module name="OpenForgeProject_MageForge" />
 </config>

--- a/src/registration.php
+++ b/src/registration.php
@@ -6,6 +6,6 @@ use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(
     ComponentRegistrar::MODULE,
-    'MageForge_Base',
+    'OpenForgeProject_MageForge',
     __DIR__
 );


### PR DESCRIPTION
This pull request includes changes to update the project name and namespace throughout the codebase. The updates ensure consistency with the new project name `OpenForgeProject/MageForge`.

Project name and namespace updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R2): Updated the project name from `mageforge/base` to `openforgeproject/mageforge` and changed the PSR-4 namespace from `MageForge\Base\` to `OpenForgeProject\MageForge\`. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R2) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L11-R11)
* [`src/Console/Command/VersionCommand.php`](diffhunk://#diff-7bf01960055c2ba9d303abe1315c25dd387ed11f64dcf80dcd4f2ca8862c6241L17-R17): Updated the API URL to reflect the new repository name `openforgeproject/mageforge`.
* [`src/etc/module.xml`](diffhunk://#diff-3d25c5641ff504c8373679c4ee18120d96cae7145efbd31b7d66c519c2bf0e41L6-R6): Changed the module name from `MageForge_Base` to `OpenForgeProject_MageForge`.
* [`src/registration.php`](diffhunk://#diff-e743b6f3c8b8b043cab684b801479764a258e7758ea231d6eeaf9ff8301ca045L9-R9): Updated the module registration to use the new module name `OpenForgeProject_MageForge`.