### PR TITLE
add ListThemesCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - changed Repository URLs
 - added codacy code-quality badge to `README.md`
 - moved to OpenForgeProject
+- add ListThemesCommand
 
 ---
 

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -12,21 +12,35 @@ use Magento\Framework\Console\Cli;
 
 class ListThemesCommand extends Command
 {
+    /**
+     * Constructor
+     *
+     * @param ThemeList $themeList
+     */
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
         parent::__construct();
     }
 
-    protected function configure(
-    ): void {
+    /**
+     * Configure the command
+     */
+    protected function configure(): void {
         $this->setName('mageforge:themes:list');
         $this->setDescription('Lists all available themes');
     }
 
+    /**
+     * Execute the command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
     protected function execute(
         InputInterface $input,
-        OutputInterface $output,
+        OutputInterface $output
     ): int {
         $themes = $this->themeList->getAllThemes();
 

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -12,35 +12,21 @@ use Magento\Framework\Console\Cli;
 
 class ListThemesCommand extends Command
 {
-    /**
-     * Constructor
-     *
-     * @param ThemeList $themeList
-     */
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
         parent::__construct();
     }
 
-    /**
-     * Configure the command
-     */
-    protected function configure(): void {
+    protected function configure(): void
+    {
         $this->setName('mageforge:themes:list');
         $this->setDescription('Lists all available themes');
     }
 
-    /**
-     * Execute the command
-     *
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @return int
-     */
     protected function execute(
         InputInterface $input,
-        OutputInterface $output
+        OutputInterface $output,
     ): int {
         $themes = $this->themeList->getAllThemes();
 

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Console\Command;
+
+use OpenForgeProject\MageForge\Model\ThemeList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\Console\Cli;
+
+class ListThemesCommand extends Command
+{
+    public function __construct(
+        private readonly ThemeList $themeList,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(
+    ): void {
+        $this->setName('mageforge:themes:list');
+        $this->setDescription('Lists all available themes');
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $themes = $this->themeList->getAllThemes();
+
+        if (empty($themes)) {
+            $output->writeln('<info>No themes found.</info>');
+            return Cli::RETURN_SUCCESS;
+        }
+
+        $output->writeln('<info>Available Themes:</info>');
+        foreach ($themes as $path => $theme) {
+            $output->writeln(
+                sprintf(
+                    '<comment>%s</comment> - %s',
+                    $path,
+                    $theme->getThemeTitle(),
+                ),
+            );
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -12,25 +12,34 @@ use Magento\Framework\Console\Cli;
 
 class ListThemesCommand extends Command
 {
+<<<<<<< HEAD
     /**
      * Constructor
      *
      * @param ThemeList $themeList
      */
+=======
+>>>>>>> 46cb511 (add ListThemesCommand)
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
         parent::__construct();
     }
 
+<<<<<<< HEAD
     /**
      * Configure the command
      */
     protected function configure(): void {
+=======
+    protected function configure(
+    ): void {
+>>>>>>> 46cb511 (add ListThemesCommand)
         $this->setName('mageforge:themes:list');
         $this->setDescription('Lists all available themes');
     }
 
+<<<<<<< HEAD
     /**
      * Execute the command
      *
@@ -41,6 +50,11 @@ class ListThemesCommand extends Command
     protected function execute(
         InputInterface $input,
         OutputInterface $output
+=======
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+>>>>>>> 46cb511 (add ListThemesCommand)
     ): int {
         $themes = $this->themeList->getAllThemes();
 

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -12,34 +12,25 @@ use Magento\Framework\Console\Cli;
 
 class ListThemesCommand extends Command
 {
-<<<<<<< HEAD
     /**
      * Constructor
      *
      * @param ThemeList $themeList
      */
-=======
->>>>>>> 46cb511 (add ListThemesCommand)
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
         parent::__construct();
     }
 
-<<<<<<< HEAD
     /**
      * Configure the command
      */
     protected function configure(): void {
-=======
-    protected function configure(
-    ): void {
->>>>>>> 46cb511 (add ListThemesCommand)
         $this->setName('mageforge:themes:list');
         $this->setDescription('Lists all available themes');
     }
 
-<<<<<<< HEAD
     /**
      * Execute the command
      *
@@ -50,11 +41,6 @@ class ListThemesCommand extends Command
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-=======
-    protected function execute(
-        InputInterface $input,
-        OutputInterface $output,
->>>>>>> 46cb511 (add ListThemesCommand)
     ): int {
         $themes = $this->themeList->getAllThemes();
 

--- a/src/Console/Command/ListThemesCommand.php
+++ b/src/Console/Command/ListThemesCommand.php
@@ -12,18 +12,33 @@ use Magento\Framework\Console\Cli;
 
 class ListThemesCommand extends Command
 {
+    /**
+     * Constructor
+     *
+     * @param ThemeList $themeList
+     */
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
         parent::__construct();
     }
 
+    /**
+     * Configure the command
+     */
     protected function configure(): void
     {
         $this->setName('mageforge:themes:list');
         $this->setDescription('Lists all available themes');
     }
 
+    /**
+     * Execute the command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
     protected function execute(
         InputInterface $input,
         OutputInterface $output,

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -15,10 +15,7 @@ use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Magento\Framework\App\ProductMetadataInterface;
-<<<<<<< HEAD
 use Magento\Framework\Escaper;
-=======
->>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
 
 class SystemCheckCommand extends Command
 {
@@ -29,10 +26,7 @@ class SystemCheckCommand extends Command
      */
     public function __construct(
         private readonly ProductMetadataInterface $productMetadata,
-<<<<<<< HEAD
         private readonly Escaper $escaper,
-=======
->>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
     ) {
         parent::__construct();
     }
@@ -58,11 +52,7 @@ class SystemCheckCommand extends Command
         $mysqlVersion = $this->getShortMysqlVersion();
         $osInfo = $this->getShortOsInfo();
         $magentoVersion = $this->productMetadata->getVersion();
-<<<<<<< HEAD
         $latestLtsNodeVersion = $this->escaper->escapeHtml($this->getLatestLtsNodeVersion());
-=======
-        $latestLtsNodeVersion = $this->getLatestLtsNodeVersion();
->>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
             ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -15,7 +15,10 @@ use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Magento\Framework\App\ProductMetadataInterface;
+<<<<<<< HEAD
 use Magento\Framework\Escaper;
+=======
+>>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
 
 class SystemCheckCommand extends Command
 {
@@ -26,7 +29,10 @@ class SystemCheckCommand extends Command
      */
     public function __construct(
         private readonly ProductMetadataInterface $productMetadata,
+<<<<<<< HEAD
         private readonly Escaper $escaper,
+=======
+>>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
     ) {
         parent::__construct();
     }
@@ -52,7 +58,11 @@ class SystemCheckCommand extends Command
         $mysqlVersion = $this->getShortMysqlVersion();
         $osInfo = $this->getShortOsInfo();
         $magentoVersion = $this->productMetadata->getVersion();
+<<<<<<< HEAD
         $latestLtsNodeVersion = $this->escaper->escapeHtml($this->getLatestLtsNodeVersion());
+=======
+        $latestLtsNodeVersion = $this->getLatestLtsNodeVersion();
+>>>>>>> 53dd067 (Inject ProductMetadataInterface into SystemCheckCommand and display Magento version in output)
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
             ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"

--- a/src/Model/ThemeList.php
+++ b/src/Model/ThemeList.php
@@ -8,6 +8,7 @@ use Magento\Framework\View\Design\Theme\ThemeList as MagentoThemeList;
 
 class ThemeList
 {
+<<<<<<< HEAD
     /**
      * Constructor
      *
@@ -23,6 +24,12 @@ class ThemeList
      *
      * @return array
      */
+=======
+    public function __construct(
+        private readonly MagentoThemeList $magentoThemeList,
+    ) {}
+
+>>>>>>> 46cb511 (add ListThemesCommand)
     public function getAllThemes(): array
     {
         return $this->magentoThemeList->getItems();

--- a/src/Model/ThemeList.php
+++ b/src/Model/ThemeList.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Model;
+
+use Magento\Framework\View\Design\Theme\ThemeList as MagentoThemeList;
+
+class ThemeList
+{
+    public function __construct(
+        private readonly MagentoThemeList $magentoThemeList,
+    ) {}
+
+    public function getAllThemes(): array
+    {
+        return $this->magentoThemeList->getItems();
+    }
+}

--- a/src/Model/ThemeList.php
+++ b/src/Model/ThemeList.php
@@ -8,10 +8,21 @@ use Magento\Framework\View\Design\Theme\ThemeList as MagentoThemeList;
 
 class ThemeList
 {
+    /**
+     * Constructor
+     *
+     * @param MagentoThemeList $magentoThemeList
+     */
     public function __construct(
-        private readonly MagentoThemeList $magentoThemeList,
-    ) {}
+        private readonly MagentoThemeList $magentoThemeList
+    ) {
+    }
 
+    /**
+     * Get all themes
+     *
+     * @return array
+     */
     public function getAllThemes(): array
     {
         return $this->magentoThemeList->getItems();

--- a/src/Model/ThemeList.php
+++ b/src/Model/ThemeList.php
@@ -8,7 +8,6 @@ use Magento\Framework\View\Design\Theme\ThemeList as MagentoThemeList;
 
 class ThemeList
 {
-<<<<<<< HEAD
     /**
      * Constructor
      *
@@ -24,12 +23,6 @@ class ThemeList
      *
      * @return array
      */
-=======
-    public function __construct(
-        private readonly MagentoThemeList $magentoThemeList,
-    ) {}
-
->>>>>>> 46cb511 (add ListThemesCommand)
     public function getAllThemes(): array
     {
         return $this->magentoThemeList->getItems();

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,6 +25,10 @@
                     name="openforgeproject_mageforge_themes_list"
                     xsi:type="object"
                 >OpenForgeProject\MageForge\Console\Command\ListThemesCommand</item>
+                <item
+                    name="openforgeproject_mageforge_system_check"
+                    xsi:type="object"
+                >OpenForgeProject\MageForge\Console\Command\SystemCheckCommand</item>
             </argument>
         </arguments>
     </type>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,10 +25,6 @@
                     name="openforgeproject_mageforge_themes_list"
                     xsi:type="object"
                 >OpenForgeProject\MageForge\Console\Command\ListThemesCommand</item>
-                <item
-                    name="openforgeproject_mageforge_system_check"
-                    xsi:type="object"
-                >OpenForgeProject\MageForge\Console\Command\SystemCheckCommand</item>
             </argument>
         </arguments>
     </type>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -21,6 +21,10 @@
                     name="openforgeproject_mageforge_system_check"
                     xsi:type="object"
                 >OpenForgeProject\MageForge\Console\Command\SystemCheckCommand</item>
+                <item
+                    name="openforgeproject_mageforge_themes_list"
+                    xsi:type="object"
+                >OpenForgeProject\MageForge\Console\Command\ListThemesCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
This pull request introduces a new command to list available themes in the MageForge project. The main changes include adding a new command class, updating the dependency injection configuration, and creating a supporting model class.

### New Command Addition:

* [`src/Console/Command/ListThemesCommand.php`](diffhunk://#diff-abc628eba26815e3cc5d1bf5fc262a4b0a2fcd60ec13140ff7912a69f6d16e89R1-R51): Added a new command class `ListThemesCommand` to list all available themes. The command outputs the themes or a message if no themes are found.

### Supporting Model:

* [`src/Model/ThemeList.php`](diffhunk://#diff-8a3c9aa35668b1a4b6ad243c13bd26413d7068d5d514c058e39b6bf46cfed264R1-R19): Introduced a `ThemeList` model class that interacts with Magento's `ThemeList` to retrieve all themes.

### Dependency Injection Configuration:

* [`src/etc/di.xml`](diffhunk://#diff-18ffcd6075c1a3bb74f7f093849bd2440300eeea3222f9b1674272da7616b6feR20-R23): Updated the dependency injection configuration to include the new `ListThemesCommand`.

### Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21): Updated to document the addition of the `ListThemesCommand`.