### PR TITLE
feat: systemCheckCommand to display system information and enhance Vers…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - added `CONTRIBUTING.md` file with guidelines for contributing to MageForge
 - added `README.md` with basic information
 - added `HelloMageForgeCommand`
+- added `system-check` command
 - added phpcs
 - added dependabot
 - added `VersionCommand`

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -47,11 +47,11 @@ class SystemCheckCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $phpVersion = $this->escaper->escapeHtml(phpversion());
-        $nodeVersion = $this->escaper->escapeHtml($this->getNodeVersion());
-        $mysqlVersion = $this->escaper->escapeHtml($this->getShortMysqlVersion());
-        $osInfo = $this->escaper->escapeHtml($this->getShortOsInfo());
-        $magentoVersion = $this->escaper->escapeHtml($this->productMetadata->getVersion());
+        $phpVersion = phpversion();
+        $nodeVersion = $this->getNodeVersion();
+        $mysqlVersion = $this->getShortMysqlVersion();
+        $osInfo = $this->getShortOsInfo();
+        $magentoVersion = $this->productMetadata->getVersion();
         $latestLtsNodeVersion = $this->escaper->escapeHtml($this->getLatestLtsNodeVersion());
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
@@ -112,8 +112,7 @@ class SystemCheckCommand extends Command
      */
     private function getShortMysqlVersion(): string
     {
-        $mysqlVersion = $this->runCommand('mysql -V');
-        if (preg_match('/Distrib ([\d.]+)/', $mysqlVersion, $matches)) {
+        if (preg_match('/Distrib ([\d.]+)/', $this->runCommand('mysql -V'), $matches)) {
             return $matches[1];
         }
         return 'Unknown';
@@ -124,9 +123,8 @@ class SystemCheckCommand extends Command
      */
     private function getShortOsInfo(): string
     {
-        $osInfo = php_uname();
-        $osInfoParts = explode(' ', $osInfo);
-        return $osInfoParts[0] . ' ' . $osInfoParts[2];
+        list($osName, , $osVersion) = explode(' ', php_uname());
+        return ($osName ?? 'Unknown') . ' ' . ($osVersion ?? 'Unknown');
     }
 
     /**

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Magento\Framework\Console\Cli;
+use GuzzleHttp\Client;
+use Composer\Semver\Comparator;
+
+class SystemCheckCommand extends Command
+{
+    private const NODE_LTS_URL = 'https://nodejs.org/dist/index.json';
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName('mageforge:system-check');
+        $this->setDescription('Displays system information like PHP version and Node.js version');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $phpVersion = phpversion();
+        $nodeVersion = trim(shell_exec('node -v'));
+        $mysqlVersion = $this->getShortMysqlVersion();
+        $osInfo = $this->getShortOsInfo();
+        $latestLtsNodeVersion = $this->getLatestLtsNodeVersion();
+
+        $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
+            ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"
+            : "$nodeVersion (Latest LTS: <fg=green>$latestLtsNodeVersion</>)";
+
+        $io->title('System Information');
+        $io->section('System Components');
+        $io->table(
+            ['Component', 'Version'],
+            [
+                ['PHP', $phpVersion],
+                new TableSeparator(),
+                ['Node.js', $nodeVersionDisplay],
+                new TableSeparator(),
+                ['MySQL', $mysqlVersion],
+                new TableSeparator(),
+                ['OS', $osInfo]
+            ]
+        );
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Get the latest LTS Node.js version from the Node.js API
+     */
+    private function getLatestLtsNodeVersion(): string
+    {
+        try {
+            $client = new Client();
+            $response = $client->get(self::NODE_LTS_URL);
+            if ($response->getStatusCode() !== 200) {
+                return 'Unknown';
+            }
+
+            $data = json_decode($response->getBody()->getContents(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return 'Unknown';
+            }
+
+            foreach ($data as $release) {
+                if (!empty($release['lts'])) {
+                    return $release['version'];
+                }
+            }
+
+            return 'Unknown';
+        } catch (\Exception $e) {
+            return 'Unknown';
+        }
+    }
+
+    /**
+     * Get a shortened MySQL version string
+     */
+    private function getShortMysqlVersion(): string
+    {
+        $mysqlVersion = trim(shell_exec('mysql -V'));
+        if (preg_match('/Distrib ([\d.]+)/', $mysqlVersion, $matches)) {
+            return $matches[1];
+        }
+        return 'Unknown';
+    }
+
+    /**
+     * Get a shortened OS information string
+     */
+    private function getShortOsInfo(): string
+    {
+        $osInfo = php_uname();
+        $osInfoParts = explode(' ', $osInfo);
+        return $osInfoParts[0] . ' ' . $osInfoParts[2];
+    }
+}

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -15,6 +15,7 @@ use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Magento\Framework\App\ProductMetadataInterface;
+use Symfony\Component\Console\Helper\Escape;
 
 class SystemCheckCommand extends Command
 {
@@ -45,12 +46,12 @@ class SystemCheckCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $phpVersion = phpversion();
-        $nodeVersion = $this->getNodeVersion();
-        $mysqlVersion = $this->getShortMysqlVersion();
-        $osInfo = $this->getShortOsInfo();
-        $magentoVersion = $this->productMetadata->getVersion();
-        $latestLtsNodeVersion = $this->getLatestLtsNodeVersion();
+        $phpVersion = Escape::escapeShellArg(phpversion());
+        $nodeVersion = Escape::escapeShellArg($this->getNodeVersion());
+        $mysqlVersion = Escape::escapeShellArg($this->getShortMysqlVersion());
+        $osInfo = Escape::escapeShellArg($this->getShortOsInfo());
+        $magentoVersion = Escape::escapeShellArg($this->productMetadata->getVersion());
+        $latestLtsNodeVersion = Escape::escapeShellArg($this->getLatestLtsNodeVersion());
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
             ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -124,6 +124,10 @@ class SystemCheckCommand extends Command
 
     /**
      * Run a command and return the output
+     *
+     * @param string $command
+     * @return string
+     * @throws ProcessFailedException
      */
     private function runCommand(string $command): string
     {

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -14,10 +14,20 @@ use GuzzleHttp\Client;
 use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Magento\Framework\App\ProductMetadataInterface;
 
 class SystemCheckCommand extends Command
 {
     private const NODE_LTS_URL = 'https://nodejs.org/dist/index.json';
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        private readonly ProductMetadataInterface $productMetadata,
+    ) {
+        parent::__construct();
+    }
 
     /**
      * @inheritDoc
@@ -39,6 +49,7 @@ class SystemCheckCommand extends Command
         $nodeVersion = $this->getNodeVersion();
         $mysqlVersion = $this->getShortMysqlVersion();
         $osInfo = $this->getShortOsInfo();
+        $magentoVersion = $this->productMetadata->getVersion();
         $latestLtsNodeVersion = $this->getLatestLtsNodeVersion();
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
@@ -56,7 +67,9 @@ class SystemCheckCommand extends Command
                 new TableSeparator(),
                 ['MySQL', $mysqlVersion],
                 new TableSeparator(),
-                ['OS', $osInfo]
+                ['OS', $osInfo],
+                new TableSeparator(),
+                ['Magento', $magentoVersion]
             ]
         );
 

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -15,6 +15,7 @@ use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Escaper;
 
 class SystemCheckCommand extends Command
 {
@@ -25,6 +26,7 @@ class SystemCheckCommand extends Command
      */
     public function __construct(
         private readonly ProductMetadataInterface $productMetadata,
+        private readonly Escaper $escaper,
     ) {
         parent::__construct();
     }
@@ -45,12 +47,12 @@ class SystemCheckCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $phpVersion = htmlspecialchars(phpversion(), ENT_QUOTES, 'UTF-8');
-        $nodeVersion = htmlspecialchars($this->getNodeVersion(), ENT_QUOTES, 'UTF-8');
-        $mysqlVersion = htmlspecialchars($this->getShortMysqlVersion(), ENT_QUOTES, 'UTF-8');
-        $osInfo = htmlspecialchars($this->getShortOsInfo(), ENT_QUOTES, 'UTF-8');
-        $magentoVersion = htmlspecialchars($this->productMetadata->getVersion(), ENT_QUOTES, 'UTF-8');
-        $latestLtsNodeVersion = htmlspecialchars($this->getLatestLtsNodeVersion(), ENT_QUOTES, 'UTF-8');
+        $phpVersion = $this->escaper->escapeHtml(phpversion());
+        $nodeVersion = $this->escaper->escapeHtml($this->getNodeVersion());
+        $mysqlVersion = $this->escaper->escapeHtml($this->getShortMysqlVersion());
+        $osInfo = $this->escaper->escapeHtml($this->getShortOsInfo());
+        $magentoVersion = $this->escaper->escapeHtml($this->productMetadata->getVersion());
+        $latestLtsNodeVersion = $this->escaper->escapeHtml($this->getLatestLtsNodeVersion());
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
             ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"

--- a/src/Console/Command/SystemCheckCommand.php
+++ b/src/Console/Command/SystemCheckCommand.php
@@ -15,7 +15,6 @@ use Composer\Semver\Comparator;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Magento\Framework\App\ProductMetadataInterface;
-use Symfony\Component\Console\Helper\Escape;
 
 class SystemCheckCommand extends Command
 {
@@ -46,12 +45,12 @@ class SystemCheckCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $phpVersion = Escape::escapeShellArg(phpversion());
-        $nodeVersion = Escape::escapeShellArg($this->getNodeVersion());
-        $mysqlVersion = Escape::escapeShellArg($this->getShortMysqlVersion());
-        $osInfo = Escape::escapeShellArg($this->getShortOsInfo());
-        $magentoVersion = Escape::escapeShellArg($this->productMetadata->getVersion());
-        $latestLtsNodeVersion = Escape::escapeShellArg($this->getLatestLtsNodeVersion());
+        $phpVersion = htmlspecialchars(phpversion(), ENT_QUOTES, 'UTF-8');
+        $nodeVersion = htmlspecialchars($this->getNodeVersion(), ENT_QUOTES, 'UTF-8');
+        $mysqlVersion = htmlspecialchars($this->getShortMysqlVersion(), ENT_QUOTES, 'UTF-8');
+        $osInfo = htmlspecialchars($this->getShortOsInfo(), ENT_QUOTES, 'UTF-8');
+        $magentoVersion = htmlspecialchars($this->productMetadata->getVersion(), ENT_QUOTES, 'UTF-8');
+        $latestLtsNodeVersion = htmlspecialchars($this->getLatestLtsNodeVersion(), ENT_QUOTES, 'UTF-8');
 
         $nodeVersionDisplay = Comparator::lessThan($nodeVersion, $latestLtsNodeVersion)
             ? "<fg=yellow>$nodeVersion</> (Latest LTS: <fg=green>$latestLtsNodeVersion</>)"

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -8,6 +8,7 @@ use OpenForgeProject\MageForge\Exception\FetchLatestVersionException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Magento\Framework\Console\Cli;
 use GuzzleHttp\Client;
 use Magento\Framework\Filesystem\Driver\File;
@@ -43,11 +44,17 @@ class VersionCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
+
         $moduleVersion = $this->getModuleVersion();
         $latestVersion = $this->getLatestVersion();
 
-        $output->writeln("Module Version: $moduleVersion");
-        $output->writeln("Latest Version: $latestVersion");
+        $io->title('MageForge Version Information');
+        $io->section('Versions');
+        $io->listing([
+            "Module Version: $moduleVersion",
+            "Latest Version: $latestVersion"
+        ]);
 
         return Cli::RETURN_SUCCESS;
     }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -17,7 +17,16 @@
                     name="openforgeproject_mageforge_version"
                     xsi:type="object"
                 >OpenForgeProject\MageForge\Console\Command\VersionCommand</item>
+                <item
+                    name="openforgeproject_mageforge_system_check"
+                    xsi:type="object"
+                >OpenForgeProject\MageForge\Console\Command\SystemCheckCommand</item>
             </argument>
+        </arguments>
+    </type>
+    <type name="OpenForgeProject\MageForge\Console\Command\SystemCheckCommand">
+        <arguments>
+            <argument name="productMetadata" xsi:type="object">Magento\Framework\App\ProductMetadataInterface</argument>
         </arguments>
     </type>
 </config>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -28,5 +28,8 @@
         <arguments>
             <argument name="productMetadata" xsi:type="object">Magento\Framework\App\ProductMetadataInterface</argument>
         </arguments>
+        <arguments>
+            <argument name="escaper" xsi:type="object">Magento\Framework\Escaper</argument>
+        </arguments>
     </type>
 </config>


### PR DESCRIPTION
This pull request introduces a new command to display system information and enhances the existing version command with improved output formatting. The most important changes include the addition of the `SystemCheckCommand` class and updates to the `VersionCommand` class.

New command addition:

* [`src/Console/Command/SystemCheckCommand.php`](diffhunk://#diff-c9434e22d3b40bb930315aeab39880f3909afc897bdf3cdaccef01fddfb2dfb0R1-R114): Added a new command `SystemCheckCommand` to display system information such as PHP version, Node.js version, MySQL version, and OS information. The command also fetches the latest LTS version of Node.js from the Node.js API.

Enhancements to existing command:

* [`src/Console/Command/VersionCommand.php`](diffhunk://#diff-7bf01960055c2ba9d303abe1315c25dd387ed11f64dcf80dcd4f2ca8862c6241R11): Updated the `VersionCommand` class to use `SymfonyStyle` for improved output formatting. The command now displays version information in a more structured and readable format. [[1]](diffhunk://#diff-7bf01960055c2ba9d303abe1315c25dd387ed11f64dcf80dcd4f2ca8862c6241R11) [[2]](diffhunk://#diff-7bf01960055c2ba9d303abe1315c25dd387ed11f64dcf80dcd4f2ca8862c6241R47-R57)

![image](https://github.com/user-attachments/assets/b6bbd63f-eb5c-407e-8593-46d7eaf6ab2a)

