### PR TITLE
Add ThemePath model and update BuildThemesCommand to utilize it for t…

### DIFF
--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Model\ThemeList;
+use Magento\Framework\Filesystem\Driver\File;
 
 /**
  * Command to build Magento themes
@@ -31,11 +32,13 @@ class BuildThemesCommand extends Command
      * @param ThemePath $themePath Service to resolve theme paths
      * @param Shell $shell Magento shell command executor
      * @param ThemeList $themeList Service to get the list of themes
+     * @param File $fileDriver Magento filesystem driver
      */
     public function __construct(
         private readonly ThemePath $themePath,
         private readonly Shell $shell,
         private readonly ThemeList $themeList,
+        private readonly File $fileDriver,
     ) {
         parent::__construct();
     }
@@ -228,7 +231,7 @@ class BuildThemesCommand extends Command
      */
     private function isDirectory(string $path): bool
     {
-        return is_dir($path);
+        return $this->fileDriver->isDirectory($path);
     }
 
     /**
@@ -242,11 +245,11 @@ class BuildThemesCommand extends Command
      */
     private function checkPackageJson(SymfonyStyle $io, bool $isVerbose): bool
     {
-        if (!is_file('package.json')) {
+        if (!$this->fileDriver->isFile('package.json')) {
             if ($isVerbose) {
                 $io->warning("The 'package.json' file does not exist in the Magento root path.");
             }
-            if (!is_file('package.json.sample')) {
+            if (!$this->fileDriver->isFile('package.json.sample')) {
                 if ($isVerbose) {
                     $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
                 }
@@ -257,7 +260,7 @@ class BuildThemesCommand extends Command
                     $io->success("The 'package.json.sample' file found.");
                 }
                 if ($io->confirm("Copy 'package.json.sample' to 'package.json'?", false)) {
-                    copy('package.json.sample', 'package.json');
+                    $this->fileDriver->copy('package.json.sample', 'package.json');
                     if ($isVerbose) {
                         $io->success("'package.json.sample' has been copied to 'package.json'.");
                     }
@@ -321,11 +324,11 @@ class BuildThemesCommand extends Command
      */
     private function checkFile(SymfonyStyle $io, string $file, string $sampleFile, bool $isVerbose): bool
     {
-        if (!is_file($file)) {
+        if (!$this->fileDriver->isFile($file)) {
             if ($isVerbose) {
                 $io->warning("The '$file' file does not exist in the Magento root path.");
             }
-            if (!is_file($sampleFile)) {
+            if (!$this->fileDriver->isFile($sampleFile)) {
                 if ($isVerbose) {
                     $io->warning("The '$sampleFile' file does not exist in the Magento root path.");
                 }
@@ -336,7 +339,7 @@ class BuildThemesCommand extends Command
                     $io->success("The '$sampleFile' file found.");
                 }
                 if ($io->confirm("Copy '$sampleFile' to '$file'?", false)) {
-                    copy($sampleFile, $file);
+                    $this->fileDriver->copy($sampleFile, $file);
                     if ($isVerbose) {
                         $io->success("'$sampleFile' has been copied to '$file'.");
                     }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -34,7 +34,8 @@ class BuildThemesCommand extends Command
             ->addArgument(
                 'themeCodes',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'The codes of the theme to build');
+                'The codes of the theme to build'
+            );
     }
 
     /**

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -46,17 +46,58 @@ class BuildThemesCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $themeCodes = $input->getArgument('themeCodes');
         $themesCount = count($themeCodes);
-        $io->confirm("Build all " . $themesCount . " Themes?", false);
+
+        # $io->confirm(question: "Build all " . $themesCount . " Themes?", false);
 
         $io->title(count($themeCodes) > 1
             ? 'Build ' . $themesCount . ' themes! This can take a while, please wait.'
             : 'Build the theme.');
         foreach ($themeCodes as $themeCode) {
             $themePath = $this->themePath->getPath($themeCode);
+            if ($themePath === null) {
+                $io->error("Theme $themeCode is not installed.");
+                continue;
+            }
             $io->section("Theme Code: $themeCode");
-            $io->text("Theme Path: $themePath");
-        }
 
+            # Check package.json file
+            if (!file_exists('package.json')) {
+                $io->warning("The 'package.json' file does not exist in the Magento root path.");
+                if (!file_exists('package.json.sample')) {
+                    $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
+                    $io->error("Skip this theme build.");
+                    continue;
+                } else {
+                    $io->success("The 'package.json.sample' file found.");
+                    if ($io->confirm("Do you want to copy 'package.json.sample' to 'package.json'?", false)) {
+                        copy('package.json.sample', 'package.json');
+                        $io->success("'package.json.sample' has been copied to 'package.json'.");
+                    }
+                }
+            } else {
+                $io->success("The 'package.json' file found.");
+            }
+
+            # Check node_modules folder
+            if (!is_dir('node_modules')) {
+                $io->warning("The 'node_modules' folder does not exist in the Magento root path.");
+                if ($io->confirm("Do you want to run 'npm install' to install the dependencies? ", false)) {
+                    $io->section("Running 'npm install'... This can take a while, please wait.");
+                    exec('npm install', $outputLines, $resultCode);
+                    if ($resultCode === 0) {
+                        $io->success("'npm install' has been successfully executed.");
+                    } else {
+                        $io->error("'npm install' failed. Please check the output for more details.");
+                        continue;
+                    }
+                } else {
+                    $io->error("Skip this theme build.");
+                    continue;
+                }
+            } else {
+                $io->success("The 'node_modules' folder found.");
+            }
+        }
         return Command::SUCCESS;
     }
 }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -34,8 +34,7 @@ class BuildThemesCommand extends Command
             ->addArgument(
                 'themeCodes',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'The codes of the theme to build'
-            );
+                'The codes of the theme to build');
     }
 
     /**
@@ -50,8 +49,7 @@ class BuildThemesCommand extends Command
 
         $io->title(count($themeCodes) > 1
             ? 'Build ' . $themesCount . ' themes! This can take a while, please wait.'
-            : 'Build the theme.'
-        );
+            : 'Build the theme.');
         foreach ($themeCodes as $themeCode) {
             $themePath = $this->themePath->getPath($themeCode);
             $io->section("Theme Code: $themeCode");

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -165,6 +165,7 @@ class BuildThemesCommand extends Command
             $progressBar->advance();
 
             $progressBar->setMessage("Deploying static content for theme: $themeCode");
+            // @codingStandardsIgnoreLine
             $sanitizedThemeCode = escapeshellarg($themeCode);
             try {
                 $shellOutput = $this->shell->execute(

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -102,7 +102,8 @@ class BuildThemesCommand extends Command
         $totalSteps = $themesCount * 4;
         $progressBar = new ProgressBar($output, $totalSteps);
         $progressBar->setFormat(
-            "\n%current%/%max% [%bar%] %percent:3s%% in %elapsed:6s% | used Memory: %memory:6s%\n%message%"
+            "\n%current%/%max% [%bar%] %percent:3s%% "
+            . "in %elapsed:6s% | used Memory: %memory:6s%\n%message%"
         );
         $progressBar->setMessage('Starting build process...');
 
@@ -169,7 +170,12 @@ class BuildThemesCommand extends Command
                 );
                 if ($isVerbose) {
                     $output->writeln($shellOutput);
-                    $io->success("'magento setup:static-content:deploy -t $sanitizedThemeCode -f' has been successfully executed.");
+                    $io->success(
+                        sprintf(
+                            "'magento setup:static-content:deploy -t %s -f' has been successfully executed.",
+                            $sanitizedThemeCode
+                        )
+                    );
                 }
                 $successList[] = "✓ Static content deployed for $themeCode";
             } catch (\Exception $e) {
@@ -203,6 +209,12 @@ class BuildThemesCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * Checks if output should be verbose
+     *
+     * @param OutputInterface $output The output interface to check
+     * @return bool True if output should be verbose, false otherwise
+     */
     private function isVerbose(OutputInterface $output): bool
     {
         return $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -119,11 +119,16 @@ class BuildThemesCommand extends Command
         return Command::SUCCESS;
     }
 
+    private function isDirectory(string $path): bool
+    {
+        return is_dir($path);
+    }
+
     private function checkPackageJson(SymfonyStyle $io): bool
     {
-        if (!file_exists('package.json')) {
+        if (!is_file('package.json')) {
             $io->warning("The 'package.json' file does not exist in the Magento root path.");
-            if (!file_exists('package.json.sample')) {
+            if (!is_file('package.json.sample')) {
                 $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
                 $io->error("Skipping this theme build.");
                 return false;
@@ -142,7 +147,7 @@ class BuildThemesCommand extends Command
 
     private function checkNodeModules(SymfonyStyle $io): bool
     {
-        if (!is_dir('node_modules')) {
+        if (!$this->isDirectory('node_modules')) {
             $io->warning("The 'node_modules' folder does not exist in the Magento root path.");
             if ($io->confirm("Run 'npm install' to install the dependencies?", false)) {
                 $io->section("Running 'npm install'... Please wait.");
@@ -165,9 +170,9 @@ class BuildThemesCommand extends Command
 
     private function checkFile(SymfonyStyle $io, string $file, string $sampleFile): bool
     {
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             $io->warning("The '$file' file does not exist in the Magento root path.");
-            if (!file_exists($sampleFile)) {
+            if (!is_file($sampleFile)) {
                 $io->warning("The '$sampleFile' file does not exist in the Magento root path.");
                 $io->error("Skipping this theme build.");
                 return false;

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -117,9 +117,14 @@ class BuildThemesCommand extends Command
             $io->section("Running 'magento setup:static-content:deploy -t $themeCode -f'... Please wait.");
             $sanitizedThemeCode = escapeshellarg($themeCode);
             try {
-                $output = $this->shell->execute("php bin/magento setup:static-content:deploy -t %s -f", [$sanitizedThemeCode]);
+                $output = $this->shell->execute(
+                    "php bin/magento setup:static-content:deploy -t %s -f",
+                    [$sanitizedThemeCode]
+                );
                 $io->writeln($output);
-                $io->success("'magento setup:static-content:deploy -t $sanitizedThemeCode -f' has been successfully executed.");
+                $io->success(
+                    "'magento setup:static-content:deploy -t $sanitizedThemeCode -f' has been successfully executed."
+                );
             } catch (\Exception $e) {
                 $io->error($e->getMessage());
                 continue;

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -97,6 +97,47 @@ class BuildThemesCommand extends Command
             } else {
                 $io->success("The 'node_modules' folder found.");
             }
+
+            # Check Gruntfile.js file
+            if (!file_exists('Gruntfile.js')) {
+                $io->warning("The 'Gruntfile.js' file does not exist in the Magento root path.");
+                if (!file_exists('Gruntfile.js.sample')) {
+                    $io->warning("The 'Gruntfile.js.sample' file does not exist in the Magento root path.");
+                    $io->error("Skip this theme build.");
+                    continue;
+                } else {
+                    $io->success("The 'Gruntfile.js.sample' file found.");
+                    if ($io->confirm("Do you want to copy 'Gruntfile.js.sample' to 'Gruntfile.js'?", false)) {
+                        copy('Gruntfile.js.sample', 'Gruntfile.js');
+                        $io->success("'Gruntfile.js.sample' has been copied to 'Gruntfile.js'.");
+                    }
+                }
+            } else {
+                $io->success("The 'Gruntfile.js' file found.");
+            }
+
+            # check grunt-config.json
+            if (!file_exists('grunt-config.json')) {
+                $io->warning("The 'grunt-config.json' file does not exist in the Magento root path.");
+                if (!file_exists('grunt-config.json.sample')) {
+                    $io->warning("The 'grunt-config.json.sample' file does not exist in the Magento root path.");
+                    $io->error("Skip this theme build.");
+                    continue;
+                } else {
+                    $io->success("The 'grunt-config.json.sample' file found.");
+                    if ($io->confirm("Do you want to copy 'grunt-config.json.sample' to 'grunt-config.json'?", false)) {
+                        copy('grunt-config.json.sample', 'grunt-config.json');
+                        $io->success("'grunt-config.json.sample' has been copied to 'grunt-config.json'.");
+                    }
+                }
+            } else {
+                $io->success("The 'grunt-config.json' file found.");
+            }
+
+            # Run Grunt
+            $io->section("Running 'grunt'... This can take a while, please wait.");
+            exec('node_modules/.bin/grunt', $outputLines, $resultCode);
+
         }
         return Command::SUCCESS;
     }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -96,12 +96,13 @@ class BuildThemesCommand extends Command
 
             // Run static content deploy
             $io->section("Running 'magento setup:static-content:deploy -t $themeCode -f'... Please wait.");
-            exec("php bin/magento setup:static-content:deploy -t $themeCode -f", $outputLines, $resultCode);
+            $sanitizedThemeCode = escapeshellarg($themeCode);
+            exec("php bin/magento setup:static-content:deploy -t $sanitizedThemeCode -f", $outputLines, $resultCode);
             $io->writeln($outputLines);
             if ($resultCode === 0) {
-                $io->success("'magento setup:static-content:deploy -t $themeCode -f' has been successfully executed.");
+                $io->success("'magento setup:static-content:deploy -t $sanitizedThemeCode -f' has been successfully executed.");
             } else {
-                $io->error("'magento setup:static-content:deploy -t $themeCode -f' failed. Please check the output for more details.");
+                $io->error("'magento setup:static-content:deploy -t $sanitizedThemeCode -f' failed. Please check the output for more details.");
             }
 
             // Clean the output before the next theme is running

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -94,14 +94,18 @@ class BuildThemesCommand extends Command
                 $io->success("Grunt has been already executed.");
             }
 
-            $io->section("Running 'php bin/magento setup:static-content:deploy -t $themeCode -f'... Please wait.");
+            // Run static content deploy
+            $io->section("Running 'magento setup:static-content:deploy -t $themeCode -f'... Please wait.");
             exec("php bin/magento setup:static-content:deploy -t $themeCode -f", $outputLines, $resultCode);
             $io->writeln($outputLines);
             if ($resultCode === 0) {
-                $io->success("'php bin/magento setup:static-content:deploy -t $themeCode' has been successfully executed.");
+                $io->success("'magento setup:static-content:deploy -t $themeCode -f' has been successfully executed.");
             } else {
-                $io->error("'php bin/magento setup:static-content:deploy -t $themeCode' failed. Please check the output for more details.");
+                $io->error("'magento setup:static-content:deploy -t $themeCode -f' failed. Please check the output for more details.");
             }
+
+            // Clean the output before the next theme is running
+            $outputLines = [];
 
             $io->success("Theme $themeCode has been successfully built.");
         }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenForgeProject\MageForge\Console\Command;
 
+use OpenForgeProject\MageForge\Model\ThemePath;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +13,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class BuildThemesCommand extends Command
 {
+    /**
+     * Constructor
+     *
+     * @param ThemePath $themePath
+     */
+    public function __construct(
+        private readonly ThemePath $themePath,
+    ) {
+        parent::__construct();
+    }
+
     /**
      * @inheritDoc
      */
@@ -29,10 +41,14 @@ class BuildThemesCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $themeCodes = $input->getArgument('themeCodes');
+        $themesCount = count($themeCodes);
+        $io->confirm("Build all " . $themesCount . " Themes?", false);
 
-        $io->title(count($themeCodes) > 1 ? 'Check themes' : 'Check theme');
+        $io->title(count($themeCodes) > 1 ? 'Build ' . $themesCount . ' themes! This can take a while, please wait. '  : 'Build the theme.');
         foreach ($themeCodes as $themeCode) {
-            $io->section("Check $themeCode ...");
+            $themePath = $this->themePath->getPath($themeCode);
+            $io->section("Theme Code: $themeCode");
+            $io->text("Theme Path: $themePath");
         }
 
         return Command::SUCCESS;

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -117,26 +117,41 @@ class BuildThemesCommand extends Command
             }
 
             # check grunt-config.json
-            if (!file_exists('grunt-config.json')) {
-                $io->warning("The 'grunt-config.json' file does not exist in the Magento root path.");
-                if (!file_exists('grunt-config.json.sample')) {
-                    $io->warning("The 'grunt-config.json.sample' file does not exist in the Magento root path.");
-                    $io->error("Skip this theme build.");
-                    continue;
-                } else {
-                    $io->success("The 'grunt-config.json.sample' file found.");
-                    if ($io->confirm("Do you want to copy 'grunt-config.json.sample' to 'grunt-config.json'?", false)) {
-                        copy('grunt-config.json.sample', 'grunt-config.json');
-                        $io->success("'grunt-config.json.sample' has been copied to 'grunt-config.json'.");
-                    }
-                }
-            } else {
-                $io->success("The 'grunt-config.json' file found.");
-            }
+            // if (!file_exists('grunt-config.json')) {
+            //     $io->warning("The 'grunt-config.json' file does not exist in the Magento root path.");
+            //     if (!file_exists('grunt-config.json.sample')) {
+            //         $io->warning("The 'grunt-config.json.sample' file does not exist in the Magento root path.");
+            //         $io->error("Skip this theme build.");
+            //         continue;
+            //     } else {
+            //         $io->success("The 'grunt-config.json.sample' file found.");
+            //         if ($io->confirm("Do you want to copy 'grunt-config.json.sample' to 'grunt-config.json'?", false)) {
+            //             copy('grunt-config.json.sample', 'grunt-config.json');
+            //             $io->success("'grunt-config.json.sample' has been copied to 'grunt-config.json'.");
+            //         }
+            //     }
+            // } else {
+            //     $io->success("The 'grunt-config.json' file found.");
+            // }
 
             # Run Grunt
             $io->section("Running 'grunt'... This can take a while, please wait.");
-            exec('node_modules/.bin/grunt', $outputLines, $resultCode);
+            exec('node_modules/.bin/grunt clean', $outputLines, $resultCode);
+            $io->writeln($outputLines);
+            if ($resultCode === 0) {
+                $io->success("'grunt clean' has been successfully executed.");
+            } else {
+                $io->error("'grunt clean' failed. Please check the output for more details.");
+                continue;
+            }
+            exec('node_modules/.bin/grunt less', $outputLines, $resultCode);
+            $io->writeln($outputLines);
+            if ($resultCode === 0) {
+                $io->success("'grunt less' has been successfully executed.");
+            } else {
+                $io->error("'grunt less' failed. Please check the output for more details.");
+                continue;
+            }
 
         }
         return Command::SUCCESS;

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -31,7 +31,11 @@ class BuildThemesCommand extends Command
     {
         $this->setName('mageforge:themes:build')
             ->setDescription('Builds a Magento theme')
-            ->addArgument('themeCodes', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The codes of the themes to build');
+            ->addArgument(
+                'themeCodes',
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                'The codes of the theme to build'
+            );
     }
 
     /**

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -26,6 +26,13 @@ use Magento\Framework\Filesystem\Driver\File;
  */
 class BuildThemesCommand extends Command
 {
+    private const PACKAGE_JSON = 'package.json';
+    private const PACKAGE_JSON_SAMPLE = 'package.json.sample';
+    private const GRUNTFILE = 'Gruntfile.js';
+    private const GRUNTFILE_SAMPLE = 'Gruntfile.js.sample';
+    private const NODE_MODULES = 'node_modules';
+    private const GRUNT_PATH = 'node_modules/.bin/grunt';
+
     /**
      * Constructor
      *
@@ -74,143 +81,217 @@ class BuildThemesCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $themeCodes = $input->getArgument('themeCodes');
-        $isVerbose = $this->isVerbose($output);
-        $successList = [];
+        try {
+            $io = new SymfonyStyle($input, $output);
+            $themeCodes = $input->getArgument('themeCodes');
+            $isVerbose = $this->isVerbose($output);
 
-        if (empty($themeCodes)) {
-            if ($isVerbose) {
-                $io->title('No theme codes provided. Available themes:');
-            }
-            $table = new Table($output);
-            $table->setHeaders(['Theme Code', 'Title']);
-
-            foreach ($this->themeList->getAllThemes() as $theme) {
-                $table->addRow([
-                    $theme->getCode(),
-                    $theme->getThemeTitle()
-                ]);
+            if (empty($themeCodes)) {
+                return $this->displayAvailableThemes($io, $isVerbose);
             }
 
-            $table->render();
-            $io->info('Usage: bin/magento mageforge:themes:build <theme-code> [<theme-code>...]');
-            return Command::SUCCESS;
+            return $this->processBuildThemes($themeCodes, $io, $output, $isVerbose);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Displays available themes when no theme code is provided
+     *
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param bool $isVerbose Whether to output verbose messages
+     * @return int Command result code
+     */
+    private function displayAvailableThemes(SymfonyStyle $io, bool $isVerbose): int
+    {
+        if ($isVerbose) {
+            $io->title('No theme codes provided. Available themes:');
         }
 
-        $themesCount = count($themeCodes);
-        $startTime = microtime(true);
+        $table = new Table($io);
+        $table->setHeaders(['Theme Code', 'Title']);
 
-        // Calculate total steps (4 steps per theme)
-        $totalSteps = $themesCount * 4;
-        $progressBar = new ProgressBar($output, $totalSteps);
-        $progressBar->setFormat(
-            "\n%current%/%max% [%bar%] %percent:3s%% "
-            . "in %elapsed:6s% | used Memory: %memory:6s%\n%message%"
-        );
-        $progressBar->setMessage('Starting build process...');
+        foreach ($this->themeList->getAllThemes() as $theme) {
+            $table->addRow([$theme->getCode(), $theme->getThemeTitle()]);
+        }
+
+        $table->render();
+        $io->info('Usage: bin/magento mageforge:themes:build <theme-code> [<theme-code>...]');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Processes the build for multiple themes
+     *
+     * @param array $themeCodes List of theme codes to build
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param OutputInterface $output Console output
+     * @param bool $isVerbose Whether to output verbose messages
+     * @return int Command result code
+     */
+    private function processBuildThemes(
+        array $themeCodes,
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $isVerbose
+    ): int {
+        $startTime = microtime(true);
+        $successList = [];
+        $totalSteps = count($themeCodes) * 4;
+
+        $progressBar = $this->createProgressBar($output, $totalSteps);
 
         if ($isVerbose) {
-            $io->title($themesCount > 1
-                ? 'Build ' . $themesCount . ' themes! This can take a while, please wait.'
-                : 'Build the theme. Please wait...');
+            $this->displayBuildHeader($io, count($themeCodes));
         }
 
         foreach ($themeCodes as $themeCode) {
-            $progressBar->setMessage("Validating theme: $themeCode");
-            $themePath = $this->themePath->getPath($themeCode);
-            if ($themePath === null) {
-                $io->error("Theme $themeCode is not installed.");
+            if (!$this->processTheme($themeCode, $io, $output, $isVerbose, $progressBar, $successList)) {
                 continue;
-            }
-            $successList[] = "✓ Theme $themeCode validated";
-            $progressBar->advance();
-
-            if ($isVerbose) {
-                $io->section("Theme: $themeCode");
-            }
-
-            $progressBar->setMessage("Checking dependencies for theme: $themeCode");
-            if (!$this->checkPackageJson($io, $isVerbose) || !$this->checkNodeModules($io, $isVerbose)) {
-                continue;
-            }
-            if (!$this->checkFile($io, 'Gruntfile.js', 'Gruntfile.js.sample', $isVerbose)) {
-                continue;
-            }
-            $successList[] = "✓ Dependencies for $themeCode checked";
-            $progressBar->advance();
-
-            static $isFirstRun = true;
-            if ($isFirstRun) {
-                $progressBar->setMessage("Running Grunt tasks");
-                try {
-                    $shellOutput = $this->shell->execute('node_modules/.bin/grunt clean --quiet');
-                    if ($isVerbose) {
-                        $output->writeln($shellOutput);
-                        $io->success("'grunt clean' has been successfully executed.");
-                    }
-
-                    $shellOutput = $this->shell->execute('node_modules/.bin/grunt less --quiet');
-                    if ($isVerbose) {
-                        $output->writeln($shellOutput);
-                        $io->success("'grunt less' has been successfully executed.");
-                    }
-                    $successList[] = "✓ Grunt tasks executed";
-                } catch (\Exception $e) {
-                    $io->error($e->getMessage());
-                    continue;
-                }
-                $isFirstRun = false;
-            }
-            $progressBar->advance();
-
-            $progressBar->setMessage("Deploying static content for theme: $themeCode");
-            // @codingStandardsIgnoreLine
-            $sanitizedThemeCode = escapeshellarg($themeCode);
-            try {
-                $shellOutput = $this->shell->execute(
-                    "php bin/magento setup:static-content:deploy -t %s -f -q",
-                    [$sanitizedThemeCode]
-                );
-                if ($isVerbose) {
-                    $output->writeln($shellOutput);
-                    $io->success(
-                        sprintf(
-                            "'magento setup:static-content:deploy -t %s -f' has been successfully executed.",
-                            $sanitizedThemeCode
-                        )
-                    );
-                }
-                $successList[] = "✓ Static content deployed for $themeCode";
-            } catch (\Exception $e) {
-                $io->error($e->getMessage());
-                continue;
-            }
-            $progressBar->advance();
-
-            if ($isVerbose) {
-                $io->success("Theme $themeCode has been successfully built.");
             }
         }
 
-        $progressBar->finish();
-        $endTime = microtime(true);
-        $duration = $endTime - $startTime;
+        $this->displayBuildSummary($io, $output, $progressBar, $successList, microtime(true) - $startTime);
 
-        // Zeige die Erfolgsliste an
-        $output->writeln("\n");
-        $io->section('Build Summary');
-        foreach ($successList as $success) {
-            $output->writeln($success);
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Processes a single theme build
+     *
+     * @param string $themeCode The theme code to process
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param OutputInterface $output Console output
+     * @param bool $isVerbose Whether to output verbose messages
+     * @param ProgressBar $progressBar Progress indicator
+     * @param array $successList List of successful operations
+     * @return bool True if theme was processed successfully, false otherwise
+     */
+    private function processTheme(
+        string $themeCode,
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $isVerbose,
+        ProgressBar $progressBar,
+        array &$successList
+    ): bool {
+        $progressBar->setMessage("Validating theme: $themeCode");
+        if (!$this->validateTheme($themeCode, $io, $successList)) {
+            return false;
+        }
+        $progressBar->advance();
+
+        if ($isVerbose) {
+            $io->section("Theme: $themeCode");
+        }
+
+        if (!$this->checkDependencies($themeCode, $io, $isVerbose, $progressBar, $successList)) {
+            return false;
+        }
+
+        if (!$this->runGruntTasks($io, $output, $isVerbose, $progressBar, $successList)) {
+            return false;
+        }
+
+        if (!$this->deployStaticContent($themeCode, $io, $output, $isVerbose, $progressBar, $successList)) {
+            return false;
         }
 
         if ($isVerbose) {
-            $io->section("Build process completed.");
+            $io->success("Theme $themeCode has been successfully built.");
         }
-        $output->writeln('');
-        $io->success("All themes have been built successfully in " . round($duration, 2) . " seconds.");
 
-        return Command::SUCCESS;
+        return true;
+    }
+
+    /**
+     * Executes Grunt tasks for theme building
+     *
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param OutputInterface $output Console output
+     * @param bool $isVerbose Whether to output verbose messages
+     * @param ProgressBar $progressBar Progress indicator
+     * @param array $successList List of successful operations
+     * @return bool True if grunt tasks executed successfully, false otherwise
+     */
+    private function runGruntTasks(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $isVerbose,
+        ProgressBar $progressBar,
+        array &$successList
+    ): bool {
+        static $isFirstRun = true;
+        if (!$isFirstRun) {
+            $progressBar->advance();
+            return true;
+        }
+
+        $progressBar->setMessage('Running Grunt tasks');
+        try {
+            foreach (['clean', 'less'] as $task) {
+                $shellOutput = $this->shell->execute(self::GRUNT_PATH . ' ' . $task . ' --quiet');
+                if ($isVerbose) {
+                    $output->writeln($shellOutput);
+                    $io->success("'grunt $task' has been successfully executed.");
+                }
+            }
+            $successList[] = "✓ Grunt tasks executed";
+            $isFirstRun = false;
+            $progressBar->advance();
+            return true;
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Deploys static content for a theme
+     *
+     * @param string $themeCode The theme code to deploy
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param OutputInterface $output Console output
+     * @param bool $isVerbose Whether to output verbose messages
+     * @param ProgressBar $progressBar Progress indicator
+     * @param array $successList List of successful operations
+     * @return bool True if deployment was successful, false otherwise
+     */
+    private function deployStaticContent(
+        string $themeCode,
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $isVerbose,
+        ProgressBar $progressBar,
+        array &$successList
+    ): bool {
+        $progressBar->setMessage("Deploying static content for theme: $themeCode");
+        try {
+            // @codingStandardsIgnoreLine
+            $sanitizedThemeCode = escapeshellarg($themeCode);
+            $shellOutput = $this->shell->execute(
+                "php bin/magento setup:static-content:deploy -t %s -f -q",
+                [$sanitizedThemeCode]
+            );
+
+            if ($isVerbose) {
+                $output->writeln($shellOutput);
+                $io->success(sprintf(
+                    "'magento setup:static-content:deploy -t %s -f' has been successfully executed.",
+                    $sanitizedThemeCode
+                ));
+            }
+
+            $successList[] = "✓ Static content deployed for $themeCode";
+            $progressBar->advance();
+            return true;
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return false;
+        }
     }
 
     /**
@@ -246,11 +327,11 @@ class BuildThemesCommand extends Command
      */
     private function checkPackageJson(SymfonyStyle $io, bool $isVerbose): bool
     {
-        if (!$this->fileDriver->isFile('package.json')) {
+        if (!$this->fileDriver->isFile(self::PACKAGE_JSON)) {
             if ($isVerbose) {
                 $io->warning("The 'package.json' file does not exist in the Magento root path.");
             }
-            if (!$this->fileDriver->isFile('package.json.sample')) {
+            if (!$this->fileDriver->isFile(self::PACKAGE_JSON_SAMPLE)) {
                 if ($isVerbose) {
                     $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
                 }
@@ -261,7 +342,7 @@ class BuildThemesCommand extends Command
                     $io->success("The 'package.json.sample' file found.");
                 }
                 if ($io->confirm("Copy 'package.json.sample' to 'package.json'?", false)) {
-                    $this->fileDriver->copy('package.json.sample', 'package.json');
+                    $this->fileDriver->copy(self::PACKAGE_JSON_SAMPLE, self::PACKAGE_JSON);
                     if ($isVerbose) {
                         $io->success("'package.json.sample' has been copied to 'package.json'.");
                     }
@@ -284,7 +365,7 @@ class BuildThemesCommand extends Command
      */
     private function checkNodeModules(SymfonyStyle $io, bool $isVerbose): bool
     {
-        if (!$this->isDirectory('node_modules')) {
+        if (!$this->isDirectory(self::NODE_MODULES)) {
             if ($isVerbose) {
                 $io->warning("The 'node_modules' folder does not exist in the Magento root path.");
             }
@@ -349,6 +430,123 @@ class BuildThemesCommand extends Command
         } elseif ($isVerbose) {
             $io->success("The '$file' file found.");
         }
+        return true;
+    }
+
+    /**
+     * Creates and configures the progress bar
+     *
+     * @param OutputInterface $output Console output
+     * @param int $max Maximum steps for the progress bar
+     * @return ProgressBar Configured progress bar instance
+     */
+    private function createProgressBar(OutputInterface $output, int $max): ProgressBar
+    {
+        $progressBar = new ProgressBar($output, $max);
+        $progressBar->setFormat(
+            "\n%current%/%max% [%bar%] %percent:3s%% "
+            . "in %elapsed:6s% | used Memory: %memory:6s%\n%message%"
+        );
+        $progressBar->setMessage('Starting build process...');
+        return $progressBar;
+    }
+
+    /**
+     * Displays the build process header
+     *
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param int $themesCount Number of themes to build
+     * @return void
+     */
+    private function displayBuildHeader(SymfonyStyle $io, int $themesCount): void
+    {
+        $title = $themesCount > 1
+            ? sprintf('Build %d themes! This can take a while, please wait.', $themesCount)
+            : 'Build the theme. Please wait...';
+        $io->title($title);
+    }
+
+    /**
+     * Displays the build process summary
+     *
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param OutputInterface $output Console output
+     * @param ProgressBar $progressBar Progress indicator
+     * @param array $successList List of successful operations
+     * @param float $duration Total build duration in seconds
+     * @return void
+     */
+    private function displayBuildSummary(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        ProgressBar $progressBar,
+        array $successList,
+        float $duration
+    ): void {
+        $progressBar->finish();
+
+        $output->writeln("\n");
+        $io->section('Build Summary');
+        foreach ($successList as $success) {
+            $output->writeln($success);
+        }
+
+        if ($this->isVerbose($output)) {
+            $io->section("Build process completed.");
+        }
+
+        $output->writeln('');
+        $io->success(sprintf(
+            "All themes have been built successfully in %.2f seconds.",
+            $duration
+        ));
+    }
+
+    /**
+     * Validates if a theme exists
+     *
+     * @param string $themeCode The theme code to validate
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param array $successList List of successful operations
+     * @return bool True if theme is valid, false otherwise
+     */
+    private function validateTheme(string $themeCode, SymfonyStyle $io, array &$successList): bool
+    {
+        $themePath = $this->themePath->getPath($themeCode);
+        if ($themePath === null) {
+            $io->error("Theme $themeCode is not installed.");
+            return false;
+        }
+        $successList[] = "✓ Theme $themeCode validated";
+        return true;
+    }
+
+    /**
+     * Checks theme dependencies
+     *
+     * @param string $themeCode The theme code being processed
+     * @param SymfonyStyle $io The IO interface for interaction
+     * @param bool $isVerbose Whether to output verbose messages
+     * @param ProgressBar $progressBar Progress indicator
+     * @param array $successList List of successful operations
+     * @return bool True if all dependencies are satisfied, false otherwise
+     */
+    private function checkDependencies(
+        string $themeCode,
+        SymfonyStyle $io,
+        bool $isVerbose,
+        ProgressBar $progressBar,
+        array &$successList
+    ): bool {
+        $progressBar->setMessage("Checking dependencies for theme: $themeCode");
+        if (!$this->checkPackageJson($io, $isVerbose) || !$this->checkNodeModules($io, $isVerbose)) {
+            return false;
+        }
+        if (!$this->checkFile($io, self::GRUNTFILE, self::GRUNTFILE_SAMPLE, $isVerbose)) {
+            return false;
+        }
+        $successList[] = "✓ Dependencies for $themeCode checked";
+        $progressBar->advance();
         return true;
     }
 }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -46,114 +46,136 @@ class BuildThemesCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $themeCodes = $input->getArgument('themeCodes');
         $themesCount = count($themeCodes);
+        $startTime = microtime(true);
 
-        # $io->confirm(question: "Build all " . $themesCount . " Themes?", false);
-
-        $io->title(count($themeCodes) > 1
+        $io->title($themesCount > 1
             ? 'Build ' . $themesCount . ' themes! This can take a while, please wait.'
-            : 'Build the theme.');
+            : 'Build the theme. Please wait...');
+
         foreach ($themeCodes as $themeCode) {
             $themePath = $this->themePath->getPath($themeCode);
             if ($themePath === null) {
                 $io->error("Theme $themeCode is not installed.");
                 continue;
             }
-            $io->section("Theme Code: $themeCode");
+            $io->section("Theme: $themeCode");
 
-            # Check package.json file
-            if (!file_exists('package.json')) {
-                $io->warning("The 'package.json' file does not exist in the Magento root path.");
-                if (!file_exists('package.json.sample')) {
-                    $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
-                    $io->error("Skip this theme build.");
-                    continue;
-                } else {
-                    $io->success("The 'package.json.sample' file found.");
-                    if ($io->confirm("Do you want to copy 'package.json.sample' to 'package.json'?", false)) {
-                        copy('package.json.sample', 'package.json');
-                        $io->success("'package.json.sample' has been copied to 'package.json'.");
-                    }
-                }
-            } else {
-                $io->success("The 'package.json' file found.");
-            }
-
-            # Check node_modules folder
-            if (!is_dir('node_modules')) {
-                $io->warning("The 'node_modules' folder does not exist in the Magento root path.");
-                if ($io->confirm("Do you want to run 'npm install' to install the dependencies? ", false)) {
-                    $io->section("Running 'npm install'... This can take a while, please wait.");
-                    exec('npm install', $outputLines, $resultCode);
-                    if ($resultCode === 0) {
-                        $io->success("'npm install' has been successfully executed.");
-                    } else {
-                        $io->error("'npm install' failed. Please check the output for more details.");
-                        continue;
-                    }
-                } else {
-                    $io->error("Skip this theme build.");
-                    continue;
-                }
-            } else {
-                $io->success("The 'node_modules' folder found.");
-            }
-
-            # Check Gruntfile.js file
-            if (!file_exists('Gruntfile.js')) {
-                $io->warning("The 'Gruntfile.js' file does not exist in the Magento root path.");
-                if (!file_exists('Gruntfile.js.sample')) {
-                    $io->warning("The 'Gruntfile.js.sample' file does not exist in the Magento root path.");
-                    $io->error("Skip this theme build.");
-                    continue;
-                } else {
-                    $io->success("The 'Gruntfile.js.sample' file found.");
-                    if ($io->confirm("Do you want to copy 'Gruntfile.js.sample' to 'Gruntfile.js'?", false)) {
-                        copy('Gruntfile.js.sample', 'Gruntfile.js');
-                        $io->success("'Gruntfile.js.sample' has been copied to 'Gruntfile.js'.");
-                    }
-                }
-            } else {
-                $io->success("The 'Gruntfile.js' file found.");
-            }
-
-            # check grunt-config.json
-            // if (!file_exists('grunt-config.json')) {
-            //     $io->warning("The 'grunt-config.json' file does not exist in the Magento root path.");
-            //     if (!file_exists('grunt-config.json.sample')) {
-            //         $io->warning("The 'grunt-config.json.sample' file does not exist in the Magento root path.");
-            //         $io->error("Skip this theme build.");
-            //         continue;
-            //     } else {
-            //         $io->success("The 'grunt-config.json.sample' file found.");
-            //         if ($io->confirm("Do you want to copy 'grunt-config.json.sample' to 'grunt-config.json'?", false)) {
-            //             copy('grunt-config.json.sample', 'grunt-config.json');
-            //             $io->success("'grunt-config.json.sample' has been copied to 'grunt-config.json'.");
-            //         }
-            //     }
-            // } else {
-            //     $io->success("The 'grunt-config.json' file found.");
-            // }
-
-            # Run Grunt
-            $io->section("Running 'grunt'... This can take a while, please wait.");
-            exec('node_modules/.bin/grunt clean', $outputLines, $resultCode);
-            $io->writeln($outputLines);
-            if ($resultCode === 0) {
-                $io->success("'grunt clean' has been successfully executed.");
-            } else {
-                $io->error("'grunt clean' failed. Please check the output for more details.");
-                continue;
-            }
-            exec('node_modules/.bin/grunt less', $outputLines, $resultCode);
-            $io->writeln($outputLines);
-            if ($resultCode === 0) {
-                $io->success("'grunt less' has been successfully executed.");
-            } else {
-                $io->error("'grunt less' failed. Please check the output for more details.");
+            if (!$this->checkPackageJson($io) || !$this->checkNodeModules($io)) {
                 continue;
             }
 
+            // Check Gruntfile.js file
+            if (!$this->checkFile($io, 'Gruntfile.js', 'Gruntfile.js.sample')) {
+                continue;
+            }
+
+            // Run Grunt only on the first run
+            static $isFirstRun = true;
+            if ($isFirstRun) {
+                $io->section("Running 'grunt'... Please wait.");
+                exec('node_modules/.bin/grunt clean', $outputLines, $resultCode);
+                $io->writeln($outputLines);
+                if ($resultCode === 0) {
+                    $io->success("'grunt clean' has been successfully executed.");
+                } else {
+                    $io->error("'grunt clean' failed. Please check the output for more details.");
+                    continue;
+                }
+                exec('node_modules/.bin/grunt less', $outputLines, $resultCode);
+                $io->writeln($outputLines);
+                if ($resultCode === 0) {
+                    $io->success("'grunt less' has been successfully executed.");
+                } else {
+                    $io->error("'grunt less' failed. Please check the output for more details.");
+                    continue;
+                }
+                $isFirstRun = false;
+            } else {
+                $io->success("Grunt has been already executed.");
+            }
+
+            $io->section("Running 'php bin/magento setup:static-content:deploy -t $themeCode -f'... Please wait.");
+            exec("php bin/magento setup:static-content:deploy -t $themeCode -f", $outputLines, $resultCode);
+            $io->writeln($outputLines);
+            if ($resultCode === 0) {
+                $io->success("'php bin/magento setup:static-content:deploy -t $themeCode' has been successfully executed.");
+            } else {
+                $io->error("'php bin/magento setup:static-content:deploy -t $themeCode' failed. Please check the output for more details.");
+            }
+
+            $io->success("Theme $themeCode has been successfully built.");
         }
+
+        $endTime = microtime(true);
+        $duration = $endTime - $startTime;
+        $io->section("Build process completed.");
+        $io->success("All themes have been built successfully in " . round($duration, 2) . " seconds.");
+
         return Command::SUCCESS;
+    }
+
+    private function checkPackageJson(SymfonyStyle $io): bool
+    {
+        if (!file_exists('package.json')) {
+            $io->warning("The 'package.json' file does not exist in the Magento root path.");
+            if (!file_exists('package.json.sample')) {
+                $io->warning("The 'package.json.sample' file does not exist in the Magento root path.");
+                $io->error("Skipping this theme build.");
+                return false;
+            } else {
+                $io->success("The 'package.json.sample' file found.");
+                if ($io->confirm("Copy 'package.json.sample' to 'package.json'?", false)) {
+                    copy('package.json.sample', 'package.json');
+                    $io->success("'package.json.sample' has been copied to 'package.json'.");
+                }
+            }
+        } else {
+            $io->success("The 'package.json' file found.");
+        }
+        return true;
+    }
+
+    private function checkNodeModules(SymfonyStyle $io): bool
+    {
+        if (!is_dir('node_modules')) {
+            $io->warning("The 'node_modules' folder does not exist in the Magento root path.");
+            if ($io->confirm("Run 'npm install' to install the dependencies?", false)) {
+                $io->section("Running 'npm install'... Please wait.");
+                exec('npm install', $outputLines, $resultCode);
+                if ($resultCode === 0) {
+                    $io->success("'npm install' has been successfully executed.");
+                } else {
+                    $io->error("'npm install' failed. Please check the output for more details.");
+                    return false;
+                }
+            } else {
+                $io->error("Skipping this theme build.");
+                return false;
+            }
+        } else {
+            $io->success("The 'node_modules' folder found.");
+        }
+        return true;
+    }
+
+    private function checkFile(SymfonyStyle $io, string $file, string $sampleFile): bool
+    {
+        if (!file_exists($file)) {
+            $io->warning("The '$file' file does not exist in the Magento root path.");
+            if (!file_exists($sampleFile)) {
+                $io->warning("The '$sampleFile' file does not exist in the Magento root path.");
+                $io->error("Skipping this theme build.");
+                return false;
+            } else {
+                $io->success("The '$sampleFile' file found.");
+                if ($io->confirm("Copy '$sampleFile' to '$file'?", false)) {
+                    copy($sampleFile, $file);
+                    $io->success("'$sampleFile' has been copied to '$file'.");
+                }
+            }
+        } else {
+            $io->success("The '$file' file found.");
+        }
+        return true;
     }
 }

--- a/src/Console/Command/BuildThemesCommand.php
+++ b/src/Console/Command/BuildThemesCommand.php
@@ -44,7 +44,10 @@ class BuildThemesCommand extends Command
         $themesCount = count($themeCodes);
         $io->confirm("Build all " . $themesCount . " Themes?", false);
 
-        $io->title(count($themeCodes) > 1 ? 'Build ' . $themesCount . ' themes! This can take a while, please wait. '  : 'Build the theme.');
+        $io->title(count($themeCodes) > 1
+            ? 'Build ' . $themesCount . ' themes! This can take a while, please wait.'
+            : 'Build the theme.'
+        );
         foreach ($themeCodes as $themeCode) {
             $themePath = $this->themePath->getPath($themeCode);
             $io->section("Theme Code: $themeCode");

--- a/src/Model/ThemePath.php
+++ b/src/Model/ThemePath.php
@@ -27,7 +27,7 @@ class ThemePath
         $themes = $this->themeList->getAllThemes();
         foreach ($themes as $path => $theme) {
             if ($theme->getCode() === $themeCode) {
-                return $path;
+                return $theme->getFullPath(); // Assuming getFullPath() returns the relative path
             }
         }
         return null;

--- a/src/Model/ThemePath.php
+++ b/src/Model/ThemePath.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Model;
+
+class ThemePath
+{
+    /**
+     * Constructor
+     *
+     * @param ThemeList $themeList
+     */
+    public function __construct(
+        private readonly ThemeList $themeList
+    ) {
+    }
+
+    /**
+     * Get the path of a theme
+     *
+     * @param string $themeCode
+     * @return string|null
+     */
+    public function getPath(string $themeCode): ?string
+    {
+        $themes = $this->themeList->getAllThemes();
+        foreach ($themes as $path => $theme) {
+            if ($theme->getCode() === $themeCode) {
+                return $path;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Model/ThemePath.php
+++ b/src/Model/ThemePath.php
@@ -25,7 +25,7 @@ class ThemePath
     public function getPath(string $themeCode): ?string
     {
         $themes = $this->themeList->getAllThemes();
-        foreach ($themes as $path => $theme) {
+        foreach ($themes as $theme) {
             if ($theme->getCode() === $themeCode) {
                 return $theme->getFullPath(); // Assuming getFullPath() returns the relative path
             }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -40,4 +40,9 @@
             <argument name="escaper" xsi:type="object">Magento\Framework\Escaper</argument>
         </arguments>
     </type>
+    <type name="OpenForgeProject\MageForge\Console\Command\BuildThemesCommand">
+        <arguments>
+            <argument name="themePath" xsi:type="object">OpenForgeProject\MageForge\Model\ThemePath</argument>
+        </arguments>
+    </type>
 </config>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -43,6 +43,7 @@
     <type name="OpenForgeProject\MageForge\Console\Command\BuildThemesCommand">
         <arguments>
             <argument name="themePath" xsi:type="object">OpenForgeProject\MageForge\Model\ThemePath</argument>
+            <argument name="themeList" xsi:type="object">OpenForgeProject\MageForge\Model\ThemeList</argument>
         </arguments>
     </type>
 </config>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -29,6 +29,10 @@
                     name="openforgeproject_mageforge_themes_build"
                     xsi:type="object"
                 >OpenForgeProject\MageForge\Console\Command\BuildThemesCommand</item>
+                <item
+                    name="mageforge_themes_build"
+                    xsi:type="object"
+                >OpenForgeProject\MageForge\Console\Command\BuildThemesCommand</item>
             </argument>
         </arguments>
     </type>
@@ -43,7 +47,9 @@
     <type name="OpenForgeProject\MageForge\Console\Command\BuildThemesCommand">
         <arguments>
             <argument name="themePath" xsi:type="object">OpenForgeProject\MageForge\Model\ThemePath</argument>
+            <argument name="shell" xsi:type="object">Magento\Framework\Shell</argument>
             <argument name="themeList" xsi:type="object">OpenForgeProject\MageForge\Model\ThemeList</argument>
+            <argument name="fileDriver" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
This pull request introduces a new `ThemePath` class and updates the dependency injection configuration to support it. The changes primarily focus on enhancing theme path management and ensuring proper dependency injection for the `BuildThemesCommand`.

### New Class Implementation:

* [`src/Model/ThemePath.php`](diffhunk://#diff-bfc111a4a2110d89f3203aba3bed960457dc8dd8afb9821a2d9eb9cfb434c39bR1-R35): Added a new `ThemePath` class with a constructor that takes a `ThemeList` object and a method `getPath` to retrieve the path of a theme based on its code.

### Dependency Injection Configuration:

* [`src/etc/di.xml`](diffhunk://#diff-18ffcd6075c1a3bb74f7f093849bd2440300eeea3222f9b1674272da7616b6feR32-R35): Added a new item for `mageforge_themes_build` in the dependency injection configuration to reference the `BuildThemesCommand` class.
* [`src/etc/di.xml`](diffhunk://#diff-18ffcd6075c1a3bb74f7f093849bd2440300eeea3222f9b1674272da7616b6feR47-R54): Updated the dependency injection configuration for `BuildThemesCommand` to include arguments for `ThemePath`, `Shell`, `ThemeList`, and `File` objects.