### PR TITLE
feat: enhance theme command arguments for better clarity and compatib…

### DIFF
--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -45,7 +45,7 @@ class BuildCommand extends AbstractCommand
             ->addArgument(
                 'themeCodes',
                 InputArgument::IS_ARRAY,
-                'Themecodes to build (format: Vendor/theme, Vendor/theme 2, ...)'
+                'Theme codes to build (format: Vendor/theme, Vendor/theme 2, ...)'
             )
             ->setAliases(['frontend:build']);
     }

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -45,7 +45,7 @@ class BuildCommand extends AbstractCommand
             ->addArgument(
                 'themeCodes',
                 InputArgument::IS_ARRAY,
-                'The codes of the theme to build'
+                'Themecodes to build (format: Vendor/theme, Vendor/theme 2, ...)'
             )
             ->setAliases(['frontend:build']);
     }

--- a/src/Console/Command/Theme/WatchCommand.php
+++ b/src/Console/Command/Theme/WatchCommand.php
@@ -58,10 +58,8 @@ class WatchCommand extends AbstractCommand
      */
     protected function executeCommand(InputInterface $input, OutputInterface $output): int
     {
-        // Prüfen auf Argument und Option für den Theme-Code
         $themeCode = $input->getArgument('themeCode');
 
-        // Falls kein Argument vorhanden, prüfe auf Option (für Abwärtskompatibilität)
         if (empty($themeCode)) {
             $themeCode = $input->getOption('theme');
         }

--- a/src/Console/Command/Theme/WatchCommand.php
+++ b/src/Console/Command/Theme/WatchCommand.php
@@ -9,6 +9,7 @@ use OpenForgeProject\MageForge\Console\Command\AbstractCommand;
 use OpenForgeProject\MageForge\Model\ThemeList;
 use OpenForgeProject\MageForge\Model\ThemePath;
 use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderPool;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -38,6 +39,11 @@ class WatchCommand extends AbstractCommand
     {
         $this->setName($this->getCommandName('theme', 'watch'))
             ->setDescription('Watches theme files for changes and rebuilds them automatically')
+            ->addArgument(
+                'themeCode',
+                InputArgument::OPTIONAL,
+                'Theme to watch (format: Vendor/theme)'
+            )
             ->addOption(
                 'theme',
                 't',
@@ -52,7 +58,13 @@ class WatchCommand extends AbstractCommand
      */
     protected function executeCommand(InputInterface $input, OutputInterface $output): int
     {
-        $themeCode = $input->getOption('theme');
+        // Prüfen auf Argument und Option für den Theme-Code
+        $themeCode = $input->getArgument('themeCode');
+
+        // Falls kein Argument vorhanden, prüfe auf Option (für Abwärtskompatibilität)
+        if (empty($themeCode)) {
+            $themeCode = $input->getOption('theme');
+        }
 
         if (empty($themeCode)) {
             $themes = $this->themeList->getAllThemes();


### PR DESCRIPTION
This pull request introduces enhancements to the theme-related console commands in the project, focusing on improving user experience and backward compatibility. Key changes include updates to argument descriptions, the addition of a new argument in the `WatchCommand`, and logic adjustments to ensure compatibility with older options.

### Updates to argument handling:

* [`src/Console/Command/Theme/BuildCommand.php`](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450L48-R48): Updated the description of the `themeCodes` argument to clarify its format.
* [`src/Console/Command/Theme/WatchCommand.php`](diffhunk://#diff-2e3fca0327c8667057939ae7ad75a765c6230ea0c7e70892f6b3f3f7fd945602R42-R46): Added a new optional argument `themeCode` to specify the theme to watch, with a clear format description.

### Backward compatibility improvements:

* [`src/Console/Command/Theme/WatchCommand.php`](diffhunk://#diff-2e3fca0327c8667057939ae7ad75a765c6230ea0c7e70892f6b3f3f7fd945602R61-R67): Added logic to check for the new `themeCode` argument first and fall back to the older `theme` option if the argument is not provided, ensuring backward compatibility.

### Dependency adjustments:

* [`src/Console/Command/Theme/WatchCommand.php`](diffhunk://#diff-2e3fca0327c8667057939ae7ad75a765c6230ea0c7e70892f6b3f3f7fd945602R12): Added `Symfony\Component\Console\Input\InputArgument` to the imports to support the new argument functionality.…🎨