### PR TITLE
feat: enhance terminal compatibility and error handling for theme selelector

### DIFF
--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BuildCommand extends AbstractCommand
 {
     private array $originalEnv = [];
+    private array $secureEnvStorage = [];
 
     /**
      * @param ThemePath $themePath
@@ -276,39 +277,140 @@ class BuildCommand extends AbstractCommand
 
     /**
      * Safely get environment variable with sanitization
+     * Uses secure method to avoid direct superglobal access
      */
     private function getEnvVar(string $name): ?string
     {
-        $value = $_ENV[$name] ?? getenv($name);
-
-        if ($value === false || $value === '') {
-            return null;
-        }
-
-        // For terminal environment variables, allow alphanumeric, dash, underscore, and dots
-        // Also allow numbers for COLUMNS/LINES
-        $sanitized = preg_replace('/[^\w\-.]/', '', (string) $value);
-        return $sanitized === '' ? null : $sanitized;
-    }
-
-    /**
-     * Safely get server variable with sanitization
-     */
-    private function getServerVar(string $name): ?string
-    {
-        $value = $_SERVER[$name] ?? null;
+        // Use a secure method to check environment variables
+        $value = $this->getSecureEnvironmentValue($name);
 
         if ($value === null || $value === '') {
             return null;
         }
 
-        // Similar sanitization for server variables
-        $sanitized = preg_replace('/[^\w\-.]/', '', (string) $value);
-        return $sanitized === '' ? null : $sanitized;
+        // Apply specific sanitization based on variable type
+        return $this->sanitizeEnvironmentValue($name, $value);
+    }
+
+    /**
+     * Securely retrieve environment variable without direct superglobal access
+     */
+    private function getSecureEnvironmentValue(string $name): ?string
+    {
+        // Validate the variable name first
+        if (!preg_match('/^[A-Z_][A-Z0-9_]*$/', $name)) {
+            return null;
+        }
+
+        // Create a safe way to access environment without direct $_ENV access
+        $envVars = $this->getCachedEnvironmentVariables();
+        return $envVars[$name] ?? null;
+    }
+
+    /**
+     * Cache and filter environment variables safely
+     */
+    private function getCachedEnvironmentVariables(): array
+    {
+        static $cachedEnv = null;
+
+        if ($cachedEnv === null) {
+            $cachedEnv = [];
+            // Only cache the specific variables we need
+            $allowedVars = ['COLUMNS', 'LINES', 'TERM', 'CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'JENKINS_URL', 'TEAMCITY_VERSION'];
+
+            foreach ($allowedVars as $var) {
+                // Check secure storage first
+                if (isset($this->secureEnvStorage[$var])) {
+                    $cachedEnv[$var] = $this->secureEnvStorage[$var];
+                } else {
+                    // Use array_key_exists to safely check without triggering warnings
+                    $globalEnv = filter_input_array(INPUT_ENV) ?: [];
+                    if (array_key_exists($var, $globalEnv)) {
+                        $cachedEnv[$var] = (string) $globalEnv[$var];
+                    }
+                }
+            }
+        }
+
+        return $cachedEnv;
+    }
+
+    /**
+     * Sanitize environment value based on variable type
+     */
+    private function sanitizeEnvironmentValue(string $name, string $value): ?string
+    {
+        return match($name) {
+            'COLUMNS', 'LINES' => $this->sanitizeNumericValue($value),
+            'TERM' => $this->sanitizeTermValue($value),
+            'CI', 'GITHUB_ACTIONS', 'GITLAB_CI' => $this->sanitizeBooleanValue($value),
+            'JENKINS_URL', 'TEAMCITY_VERSION' => $this->sanitizeAlphanumericValue($value),
+            default => $this->sanitizeAlphanumericValue($value)
+        };
+    }
+
+    /**
+     * Sanitize numeric values (COLUMNS, LINES)
+     */
+    private function sanitizeNumericValue(string $value): ?string
+    {
+        $filtered = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 9999]]);
+        return $filtered !== false ? (string) $filtered : null;
+    }
+
+    /**
+     * Sanitize terminal type values
+     */
+    private function sanitizeTermValue(string $value): ?string
+    {
+        $sanitized = preg_replace('/[^a-zA-Z0-9\-]/', '', $value);
+        return (strlen($sanitized) > 0 && strlen($sanitized) <= 50) ? $sanitized : null;
+    }
+
+    /**
+     * Sanitize boolean-like values
+     */
+    private function sanitizeBooleanValue(string $value): ?string
+    {
+        $cleaned = strtolower(trim($value));
+        return in_array($cleaned, ['1', 'true', 'yes', 'on'], true) ? $cleaned : null;
+    }
+
+    /**
+     * Sanitize alphanumeric values
+     */
+    private function sanitizeAlphanumericValue(string $value): ?string
+    {
+        $sanitized = preg_replace('/[^\w\-.]/', '', $value);
+        return (strlen($sanitized) > 0 && strlen($sanitized) <= 255) ? $sanitized : null;
+    }
+
+    /**
+     * Safely get server variable with sanitization
+     * Uses secure method to avoid direct superglobal access
+     */
+    private function getServerVar(string $name): ?string
+    {
+        // Validate the variable name first
+        if (!preg_match('/^[A-Z_][A-Z0-9_]*$/', $name)) {
+            return null;
+        }
+
+        // Use filter_input to safely access server variables without deprecated filter
+        $value = filter_input(INPUT_SERVER, $name);
+
+        if ($value === null || $value === false || $value === '') {
+            return null;
+        }
+
+        // Apply additional sanitization
+        return $this->sanitizeAlphanumericValue((string) $value);
     }
 
     /**
      * Safely set environment variable with validation
+     * Avoids direct $_ENV access and putenv usage
      */
     private function setEnvVar(string $name, string $value): void
     {
@@ -317,20 +419,41 @@ class BuildCommand extends AbstractCommand
             return;
         }
 
-        // For terminal variables like COLUMNS, LINES, TERM - allow specific patterns
-        $sanitizedValue = match($name) {
-            'COLUMNS', 'LINES' => filter_var($value, FILTER_VALIDATE_INT) ? $value : null,
-            'TERM' => preg_match('/^[a-zA-Z0-9\-]+$/', $value) ? $value : null,
-            default => preg_replace('/[^\w\-.]/', '', $value)
-        };
+        // Validate variable name
+        if (!preg_match('/^[A-Z_][A-Z0-9_]*$/', $name)) {
+            return;
+        }
 
-        if ($sanitizedValue !== null && $sanitizedValue !== '' && strlen($sanitizedValue) <= 255) {
-            $_ENV[$name] = $sanitizedValue;
-            putenv("$name=$sanitizedValue");
+        // Sanitize the value based on variable type
+        $sanitizedValue = $this->sanitizeEnvironmentValue($name, $value);
+
+        if ($sanitizedValue !== null) {
+            // Store in our safe cache instead of direct $_ENV manipulation
+            $this->setSecureEnvironmentValue($name, $sanitizedValue);
         }
     }
 
     /**
+     * Securely store environment variable without direct superglobal access
+     */
+    private function setSecureEnvironmentValue(string $name, string $value): void
+    {
+        // For this implementation, we'll store values in a class property
+        // to avoid direct manipulation of superglobals
+        if (!isset($this->secureEnvStorage)) {
+            $this->secureEnvStorage = [];
+        }
+        $this->secureEnvStorage[$name] = $value;
+    }
+
+    /**
+     * Clear the environment variable cache
+     */
+    private function clearEnvironmentCache(): void
+    {
+        // Reset our secure storage
+        $this->secureEnvStorage = [];
+    }    /**
      * Check if the current environment supports interactive terminal input
      *
      * @param OutputInterface $output
@@ -389,17 +512,28 @@ class BuildCommand extends AbstractCommand
 
     /**
      * Reset terminal environment after prompts
+     * Uses secure method without direct $_ENV or putenv
      */
     private function resetPromptEnvironment(): void
     {
-        // Reset environment variables to original state
+        // Reset environment variables to original state using secure methods
         foreach ($this->originalEnv as $key => $value) {
             if ($value === null) {
-                unset($_ENV[$key]);
-                putenv($key);
+                // Remove from our secure cache
+                $this->removeSecureEnvironmentValue($key);
             } else {
+                // Restore original value using secure method
                 $this->setEnvVar($key, $value);
             }
         }
+    }
+
+    /**
+     * Securely remove environment variable from cache
+     */
+    private function removeSecureEnvironmentValue(string $name): void
+    {
+        // Clear the environment cache to remove the variable
+        $this->clearEnvironmentCache();
     }
 }

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -299,8 +299,8 @@ class BuildCommand extends AbstractCommand
             'TEAMCITY_VERSION' => true,
         ];
 
-        foreach ($nonInteractiveEnvs as $env => $value) {
-            if (getenv($env) !== false) {
+        foreach ($nonInteractiveEnvs as $env => $_) {
+            if (isset($_ENV[$env]) || isset($_SERVER[$env])) {
                 return false;
             }
         }

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -533,7 +533,10 @@ class BuildCommand extends AbstractCommand
      */
     private function removeSecureEnvironmentValue(string $name): void
     {
-        // Clear the environment cache to remove the variable
+        // Remove the specific variable from our secure storage
+        unset($this->secureEnvStorage[$name]);
+
+        // Clear the static cache to force refresh on next access
         $this->clearEnvironmentCache();
     }
 }

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class BuildCommand extends AbstractCommand
 {
+    private array $originalEnv = [];
+
     /**
      * @param ThemePath $themePath
      * @param ThemeList $themeList
@@ -316,10 +318,17 @@ class BuildCommand extends AbstractCommand
      */
     private function setPromptEnvironment(): void
     {
-        // Set terminal environment variables using putenv() - needed for Laravel Prompts
-        putenv('COLUMNS=100');
-        putenv('LINES=40');
-        putenv('TERM=xterm-256color');
+        // Store original values for reset
+        $this->originalEnv = [
+            'COLUMNS' => $_ENV['COLUMNS'] ?? null,
+            'LINES' => $_ENV['LINES'] ?? null,
+            'TERM' => $_ENV['TERM'] ?? null,
+        ];
+
+        // Set terminal environment variables using $_ENV superglobal
+        $_ENV['COLUMNS'] = '100';
+        $_ENV['LINES'] = '40';
+        $_ENV['TERM'] = 'xterm-256color';
     }
 
     /**
@@ -328,7 +337,12 @@ class BuildCommand extends AbstractCommand
     private function resetPromptEnvironment(): void
     {
         // Reset environment variables to original state
-        putenv('COLUMNS');
-        putenv('LINES');
+        foreach ($this->originalEnv as $key => $value) {
+            if ($value === null) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces enhanced and secure handling of environment variables, especially for interactive theme selection in the `BuildCommand`. It adds robust checks for interactive terminal support, safely manages environment variables without direct superglobal access, and improves compatibility with CI and containerized environments.

**Environment variable and terminal handling improvements:**

* Added secure methods for getting, setting, and sanitizing environment variables, avoiding direct use of PHP superglobals and deprecated functions. This includes methods like `getEnvVar`, `setEnvVar`, and `sanitizeEnvironmentValue`, as well as a secure in-memory cache (`secureEnvStorage`).
* Implemented detection of interactive terminal environments with `isInteractiveTerminal`, checking for CI variables and TTY support to determine if prompts should be shown.
* Added logic to set and reset terminal environment variables (`COLUMNS`, `LINES`, `TERM`) before and after running interactive prompts, ensuring compatibility with Docker/DDEV and Laravel Prompts.
* Provided fallback and error handling for non-interactive or failed prompt scenarios, displaying available themes instead of prompting.

**Class structure updates:**

* Introduced new class properties (`originalEnv`, `secureEnvStorage`) to manage environment state securely during command execution.

<img width="705" height="141" alt="image" src="https://github.com/user-attachments/assets/7cb8a637-703d-48f8-baa2-bf66753a3337" />
