### PR TITLE
feat: add theme suggestion service and integrate with commands #75

### DIFF
--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -157,6 +157,19 @@ jobs:
           bin/magento m:st:c --help
           bin/magento frontend:clean --help
 
+          echo "Test Theme Name Suggestions (non-interactive):"
+          echo "Testing BuildCommand with invalid theme name:"
+          bin/magento mageforge:theme:build Magent/lum || echo "Expected failure - BuildCommand"
+
+          echo "Testing WatchCommand with invalid theme name:"
+          bin/magento mageforge:theme:watch Magent/lum --help || echo "Expected failure - WatchCommand"
+
+          echo "Testing CleanCommand with invalid theme name:"
+          bin/magento mageforge:static:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
+
+          echo "Testing TokensCommand with invalid theme name:"
+          bin/magento mageforge:hyva:tokens Magent/lum --help || echo "Expected failure - TokensCommand"
+
 
       - name: Test Summary
         run: |
@@ -298,6 +311,19 @@ jobs:
           echo "Test MageForge Static Clean alias:"
           bin/magento m:st:c --help
           bin/magento frontend:clean --help
+
+          echo "Test Theme Name Suggestions (non-interactive):"
+          echo "Testing BuildCommand with invalid theme name:"
+          bin/magento mageforge:theme:build Magent/lum || echo "Expected failure - BuildCommand"
+
+          echo "Testing WatchCommand with invalid theme name:"
+          bin/magento mageforge:theme:watch Magent/lum --help || echo "Expected failure - WatchCommand"
+
+          echo "Testing CleanCommand with invalid theme name:"
+          bin/magento mageforge:static:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
+
+          echo "Testing TokensCommand with invalid theme name:"
+          bin/magento mageforge:hyva:tokens Magent/lum --help || echo "Expected failure - TokensCommand"
 
 
       - name: Test Summary

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OpenForgeProject\MageForge\Console\Command;
 
+use Laravel\Prompts\SelectPrompt;
 use Magento\Framework\Console\Cli;
+use OpenForgeProject\MageForge\Service\ThemeSuggester;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,6 +28,16 @@ abstract class AbstractCommand extends Command
      * @var SymfonyStyle
      */
     protected SymfonyStyle $io;
+
+    /**
+     * @var array
+     */
+    private array $originalEnv = [];
+
+    /**
+     * @var array
+     */
+    private array $secureEnvStorage = [];
 
     /**
      * Get the command name with proper group structure
@@ -100,5 +112,197 @@ abstract class AbstractCommand extends Command
     protected function isDebug(OutputInterface $output): bool
     {
         return $output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG;
+    }
+
+    /**
+     * Handle invalid theme with interactive suggestions
+     *
+     * When a theme code is invalid, this method finds similar themes using Levenshtein distance
+     * and offers an interactive selection via Laravel Prompts (if terminal is interactive).
+     * In non-interactive environments, suggestions are displayed as text.
+     *
+     * @param string $invalidTheme The invalid theme code entered by user
+     * @param ThemeSuggester $themeSuggester Service to find similar themes
+     * @param OutputInterface $output Output interface for terminal detection
+     * @return string|null The selected theme code, or null if cancelled/no selection
+     */
+    protected function handleInvalidThemeWithSuggestions(
+        string $invalidTheme,
+        ThemeSuggester $themeSuggester,
+        OutputInterface $output
+    ): ?string {
+        $suggestions = $themeSuggester->findSimilarThemes($invalidTheme);
+
+        // No suggestions found
+        if (empty($suggestions)) {
+            $this->io->error("Theme '$invalidTheme' is not installed and no similar themes were found.");
+            return null;
+        }
+
+        // Check if terminal is interactive
+        if (!$this->isInteractiveTerminal($output)) {
+            // Non-interactive fallback: display suggestions as text
+            $this->io->error("Theme '$invalidTheme' is not installed.");
+            $this->io->writeln("\nDid you mean one of these?");
+            foreach ($suggestions as $suggestion) {
+                $this->io->writeln("  - $suggestion");
+            }
+            return null;
+        }
+
+        // Interactive mode: show prompt with suggestions
+        $this->io->error("Theme '$invalidTheme' is not installed.");
+        $this->io->newLine();
+
+        // Prepare options with "None of these" option
+        $options = array_merge($suggestions, ['None of these']);
+
+        // Set environment for Docker/DDEV compatibility
+        $this->setPromptEnvironment();
+
+        $prompt = new SelectPrompt(
+            label: 'Did you mean one of these themes?',
+            options: $options,
+            scroll: 10,
+            hint: 'Arrow keys to navigate, Enter to confirm'
+        );
+
+        try {
+            $selection = $prompt->prompt();
+            \Laravel\Prompts\Prompt::terminal()->restoreTty();
+            $this->resetPromptEnvironment();
+
+            // Check if user selected "None of these"
+            if ($selection === 'None of these') {
+                return null;
+            }
+
+            return $selection;
+        } catch (\Exception $e) {
+            $this->resetPromptEnvironment();
+            $this->io->error('Selection failed: ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Check if terminal is interactive (supports Laravel Prompts)
+     *
+     * @param OutputInterface $output
+     * @return bool
+     */
+    private function isInteractiveTerminal(OutputInterface $output): bool
+    {
+        // Check if output supports ANSI
+        if (!$output->isDecorated()) {
+            return false;
+        }
+
+        // Check if STDIN is available
+        if (!defined('STDIN') || !is_resource(STDIN)) {
+            return false;
+        }
+
+        // Check for CI environments
+        $nonInteractiveEnvs = [
+            'CI',
+            'GITHUB_ACTIONS',
+            'GITLAB_CI',
+            'JENKINS_URL',
+            'TEAMCITY_VERSION',
+        ];
+
+        foreach ($nonInteractiveEnvs as $env) {
+            if ($this->getEnvVar($env) || $this->getServerVar($env)) {
+                return false;
+            }
+        }
+
+        // Check if TTY is available
+        $sttyOutput = shell_exec('stty -g 2>/dev/null');
+        return !empty($sttyOutput);
+    }
+
+    /**
+     * Set environment variables for Laravel Prompts in Docker/DDEV
+     *
+     * @return void
+     */
+    private function setPromptEnvironment(): void
+    {
+        // Store original values for restoration
+        $this->originalEnv = [
+            'COLUMNS' => $this->getEnvVar('COLUMNS'),
+            'LINES' => $this->getEnvVar('LINES'),
+            'TERM' => $this->getEnvVar('TERM'),
+        ];
+
+        // Set terminal dimensions for proper rendering
+        $this->setEnvVar('COLUMNS', '100');
+        $this->setEnvVar('LINES', '40');
+        $this->setEnvVar('TERM', 'xterm-256color');
+    }
+
+    /**
+     * Reset environment variables to original state
+     *
+     * @return void
+     */
+    private function resetPromptEnvironment(): void
+    {
+        foreach ($this->originalEnv as $key => $value) {
+            if ($value === null) {
+                $this->removeSecureEnvironmentValue($key);
+            } else {
+                $this->setEnvVar($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Get environment variable value
+     *
+     * @param string $key
+     * @return string|null
+     */
+    private function getEnvVar(string $key): ?string
+    {
+        return getenv($key) ?: null;
+    }
+
+    /**
+     * Get server variable value
+     *
+     * @param string $key
+     * @return string|null
+     */
+    private function getServerVar(string $key): ?string
+    {
+        return $_SERVER[$key] ?? null;
+    }
+
+    /**
+     * Set environment variable securely
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    private function setEnvVar(string $key, string $value): void
+    {
+        $this->secureEnvStorage[$key] = $value;
+        putenv("$key=$value");
+    }
+
+    /**
+     * Remove environment variable securely
+     *
+     * @param string $key
+     * @return void
+     */
+    private function removeSecureEnvironmentValue(string $key): void
+    {
+        unset($this->secureEnvStorage[$key]);
+        putenv($key);
     }
 }

--- a/src/Service/ThemeSuggester.php
+++ b/src/Service/ThemeSuggester.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use OpenForgeProject\MageForge\Model\ThemeList;
+
+/**
+ * Service for suggesting similar theme names when invalid themes are provided
+ *
+ * Uses Levenshtein distance algorithm similar to Symfony's command suggestion feature
+ */
+class ThemeSuggester
+{
+    /**
+     * Maximum number of suggestions to return
+     */
+    private const MAX_SUGGESTIONS = 3;
+
+    /**
+     * Constructor
+     *
+     * @param ThemeList $themeList
+     */
+    public function __construct(
+        private readonly ThemeList $themeList
+    ) {
+    }
+
+    /**
+     * Find similar theme codes based on Levenshtein distance
+     *
+     * Algorithm based on Symfony's findAlternatives() method:
+     * - Calculates Levenshtein distance between input and each theme code
+     * - Accepts suggestions if distance ≤ strlen/3 OR substring match
+     * - Returns top matches sorted by distance
+     *
+     * @param string $invalidTheme The invalid theme code entered by user
+     * @return array Array of suggested theme codes (max 3)
+     */
+    public function findSimilarThemes(string $invalidTheme): array
+    {
+        $themes = $this->themeList->getAllThemes();
+        $threshold = (int) (strlen($invalidTheme) / 3);
+        $suggestions = [];
+
+        foreach ($themes as $theme) {
+            $themeCode = $theme->getCode();
+            $distance = levenshtein($invalidTheme, $themeCode);
+
+            // Accept if: distance ≤ 1/3 of input length OR substring match (case-insensitive)
+            if ($distance <= $threshold || str_contains(strtolower($themeCode), strtolower($invalidTheme))) {
+                $suggestions[$themeCode] = $distance;
+            }
+        }
+
+        // Sort by distance (best matches first)
+        asort($suggestions);
+
+        // Return max 3 suggestions
+        return array_slice(array_keys($suggestions), 0, self::MAX_SUGGESTIONS);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -40,4 +40,11 @@
                   </argument>
             </arguments>
       </type>
+
+      <!-- Register ThemeSuggester Service -->
+      <type name="OpenForgeProject\MageForge\Service\ThemeSuggester">
+            <arguments>
+                  <argument name="themeList" xsi:type="object">OpenForgeProject\MageForge\Model\ThemeList</argument>
+            </arguments>
+      </type>
 </config>


### PR DESCRIPTION
# Feature: Theme name suggestions for invalid input

Closes #75

## Summary

When users enter an incorrect theme name, MageForge now suggests similar themes using Levenshtein distance algorithm (like Symfony's command suggestions).

**Before:**
```bash
bin/magento mageforge:theme:build vendor/Nema
# Error: Theme vendor/Nema is not installed.
```

After:

```bash
bin/magento mageforge:theme:build hyva/deFAULT

[ERROR] Theme 'hyva/deFAULT' is not installed.

? Did you mean one of these themes?
  ❯ Hyva/default
    None of these

✓ Using theme: Hyva/default
```

## Changes
- Added ThemeSuggester service with Levenshtein matching (threshold: strlen/3) and case-insensitive substring matching
- Extended AbstractCommand with handleInvalidThemeWithSuggestions() method
- Updated 4 commands: BuildCommand, WatchCommand, CleanCommand, TokensCommand
- Interactive mode: Shows Laravel Prompts SelectPrompt with suggestions
- Non-interactive mode (CI/Docker): Displays suggestions as text
- Added CI tests in magento-compatibility.yml