### PR TITLE
fix!: create theme:clean command for cleaning theme static files and …

### DIFF
--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -149,12 +149,12 @@ jobs:
           bin/magento m:h:c:c --show-all --detailed
 
           echo "Test MageForge Static Clean command with dry-run:"
-          bin/magento mageforge:static:clean --all --dry-run
+          bin/magento mageforge:theme:clean --all --dry-run
 
           echo "Test MageForge Static Clean aliases:"
-          bin/magento mageforge:static:clean --all --dry-run
+          bin/magento mageforge:theme:clean --all --dry-run
           echo "Test MageForge Static Clean aliases:"
-          bin/magento m:st:c --help
+          bin/magento m:t:c --help
           bin/magento frontend:clean --help
 
           echo "Test Theme Name Suggestions (non-interactive):"
@@ -165,7 +165,7 @@ jobs:
           bin/magento mageforge:theme:watch Magent/lum --help || echo "Expected failure - WatchCommand"
 
           echo "Testing CleanCommand with invalid theme name:"
-          bin/magento mageforge:static:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
+          bin/magento mageforge:theme:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
 
           echo "Testing TokensCommand with invalid theme name:"
           bin/magento mageforge:hyva:tokens Magent/lum --help || echo "Expected failure - TokensCommand"
@@ -306,10 +306,10 @@ jobs:
           bin/magento m:h:c:c --show-all --detailed
 
           echo "Test MageForge Static Clean command with dry-run:"
-          bin/magento mageforge:static:clean --all --dry-run
+          bin/magento mageforge:theme:clean --all --dry-run
 
           echo "Test MageForge Static Clean alias:"
-          bin/magento m:st:c --help
+          bin/magento m:t:c --help
           bin/magento frontend:clean --help
 
           echo "Test Theme Name Suggestions (non-interactive):"
@@ -320,7 +320,7 @@ jobs:
           bin/magento mageforge:theme:watch Magent/lum --help || echo "Expected failure - WatchCommand"
 
           echo "Testing CleanCommand with invalid theme name:"
-          bin/magento mageforge:static:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
+          bin/magento mageforge:theme:clean Magent/lum --dry-run || echo "Expected failure - CleanCommand"
 
           echo "Testing TokensCommand with invalid theme name:"
           bin/magento mageforge:hyva:tokens Magent/lum --help || echo "Expected failure - TokensCommand"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,12 @@ All notable changes to this project will be documented in this file.
   - Detailed file-level issues with line numbers
   - Exit code 1 for critical issues, 0 for success
   - Command aliases: `m:h:c:c`, `hyva:check`
-- feat: add `mageforge:static:clean` command for comprehensive cache and generated files cleanup
-  - feat: add interactive multi-theme selection for static:clean command using Laravel Prompts
+- feat: add `mageforge:theme:clean` command for comprehensive cache and generated files cleanup
+  - feat: add interactive multi-theme selection for theme:clean command using Laravel Prompts
   - feat: add `--all` option to clean all themes at once
   - feat: add `--dry-run` option to preview what would be cleaned without deleting
   - feat: add command alias `frontend:clean` for quick access
-  - feat: add CI/CD tests for static:clean command in compatibility workflow
+  - feat: add CI/CD tests for theme:clean command in compatibility workflow
 
 #### Fixed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please ensure that your Magento installation meets this requirement before insta
 | `mageforge:theme:watch`             | Starts watch mode for theme development                   | `m:t:w`, `frontend:watch` |
 | `mageforge:hyva:tokens`             | Generate Hyvä design tokens (Hyvä themes only)            | `m:h:t`                   |
 | `mageforge:hyva:compatibility:check`| Check modules for Hyvä theme compatibility issues        | `m:h:c:c`, `hyva:check`   |
-| `mageforge:static:clean`            | Clean static files, cache and generated files for a theme | `m:st:c`,`frontend:clean` |
+| `mageforge:theme:clean`             | Clean theme static files and cache directories            | `m:t:c`, `frontend:clean` |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -94,11 +94,11 @@ bin/magento mageforge:theme:watch [--theme=THEME]
 
 ---
 
-### 4. CleanCommand (`mageforge:static:clean`)
+### 4. CleanCommand (`mageforge:theme:clean`)
 
 **Purpose**: Cleans var/view_preprocessed, pub/static, var/page_cache, var/tmp and generated directories for specific theme.
 
-**File**: `/src/Console/Command/Static/CleanCommand.php`
+**File**: `/src/Console/Command/Theme/CleanCommand.php`
 
 **Dependencies**:
 
@@ -109,7 +109,7 @@ bin/magento mageforge:theme:watch [--theme=THEME]
 **Usage**:
 
 ```bash
-bin/magento mageforge:static:clean [<themename>]
+bin/magento mageforge:theme:clean [<themename>]
 ```
 
 **Implementation Details**:

--- a/src/Console/Command/Theme/CleanCommand.php
+++ b/src/Console/Command/Theme/CleanCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenForgeProject\MageForge\Console\Command\Static;
+namespace OpenForgeProject\MageForge\Console\Command\Theme;
 
 use Laravel\Prompts\MultiSelectPrompt;
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -46,12 +46,8 @@ class CleanCommand extends AbstractCommand
      */
     protected function configure(): void
     {
-        $this->setName($this->getCommandName('static', 'clean'))
-            ->setDescription(
-                'Clean theme-specific static files (var/view_preprocessed, pub/static) '
-                . 'for selected themes and global cache directories '
-                . '(var/page_cache, var/tmp, generated)'
-            )
+        $this->setName($this->getCommandName('theme', 'clean'))
+            ->setDescription('Clean theme static files and cache directories')
             ->addArgument(
                 'themeCodes',
                 InputArgument::IS_ARRAY,
@@ -69,7 +65,7 @@ class CleanCommand extends AbstractCommand
                 InputOption::VALUE_NONE,
                 'Show what would be cleaned without actually deleting anything'
             )
-            ->setAliases(['m:st:c', 'frontend:clean']);
+            ->setAliases(['m:t:c', 'frontend:clean']);
     }
 
     /**
@@ -178,9 +174,9 @@ class CleanCommand extends AbstractCommand
         }
 
         $this->io->newLine();
-        $this->io->info('Usage: bin/magento mageforge:static:clean <theme-code> [<theme-code>...]');
-        $this->io->info('       bin/magento mageforge:static:clean --all');
-        $this->io->info('Example: bin/magento mageforge:static:clean Magento/luma');
+        $this->io->info('Usage: bin/magento mageforge:theme:clean <theme-code> [<theme-code>...]');
+        $this->io->info('       bin/magento mageforge:theme:clean --all');
+        $this->io->info('Example: bin/magento mageforge:theme:clean Magento/luma');
     }
 
     /**

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -17,8 +17,8 @@
                               OpenForgeProject\MageForge\Console\Command\Theme\BuildCommand</item>
                         <item name="mageforge_theme_watch" xsi:type="object">
                               OpenForgeProject\MageForge\Console\Command\Theme\WatchCommand</item>
-                        <item name="mageforge_static_clean" xsi:type="object">
-                              OpenForgeProject\MageForge\Console\Command\Static\CleanCommand</item>
+                        <item name="mageforge_theme_clean" xsi:type="object">
+                              OpenForgeProject\MageForge\Console\Command\Theme\CleanCommand</item>
                         <item name="mageforge_hyva_compatibility_check" xsi:type="object">
                               OpenForgeProject\MageForge\Console\Command\Hyva\CompatibilityCheckCommand</item>
                         <item name="mageforge_theme_tokens" xsi:type="object">


### PR DESCRIPTION
## Description

Restructures the `CleanCommand` to align with the existing `theme` command namespace for better consistency.

## Changes

### Command Restructuring
- **Moved**: `Console/Command/Static/CleanCommand.php` → `Console/Command/Theme/CleanCommand.php`
- **Namespace**: `OpenForgeProject\MageForge\Console\Command\Static` → `...Command\Theme`
- **Command name**: `mageforge:static:clean` → `mageforge:theme:clean`
- **Alias**: `m:st:c` → `m:t:c` (keeps `frontend:clean`)
- **Description**: Shortened to "Clean theme static files and cache directories"

### Updated Files
- `src/src/Console/Command/Theme/CleanCommand.php` - Namespace, command name, aliases, description
- `src/src/etc/di.xml` - Command registration updated
- `src/README.md` - Command table updated
- `src/docs/commands.md` - Command reference updated
- `src/CHANGELOG.md` - Command references updated
- `.github/copilot-instructions.md` - Example updated
- `.github/workflows/magento-compatibility.yml` - CI/CD tests updated (both Elasticsearch and OpenSearch jobs)

## Rationale

All theme-related commands now follow a consistent pattern:
- ✅ `mageforge:theme:build` (`m:t:b`)
- ✅ `mageforge:theme:watch` (`m:t:w`)
- ✅ `mageforge:theme:list` (`m:t:l`)
- ✅ `mageforge:theme:clean` (`m:t:c`) ← **now consistent**
- ✅ `mageforge:theme:tokens` (`m:t:t`)

The previous `mageforge:static:clean` with alias `m:st:c` broke this pattern.

## Testing

- [ ] Command executes successfully: `bin/magento mageforge:theme:clean --help`
- [ ] Alias works: `bin/magento m:t:c --help`
- [ ] Legacy alias works: `bin/magento frontend:clean --help`
- [ ] CI/CD tests pass for all Magento versions

## Breaking Changes

⚠️ **Yes** - Existing scripts using `mageforge:static:clean` or `m:st:c` need to be updated to `mageforge:theme:clean` or `m:t:c`.

The `frontend:clean` alias remains for backward compatibility.