### PR TITLE
feat: implement StaticContentCleaner and update theme build commands

### DIFF
--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -271,7 +271,7 @@ class BuildCommand extends AbstractCommand
         }
 
         // Build the theme
-        if (!$builder->build($themePath, $io, $output, $isVerbose)) {
+        if (!$builder->build($themeCode, $themePath, $io, $output, $isVerbose)) {
             $io->error("Failed to build theme $themeCode.");
             return false;
         }

--- a/src/Console/Command/Theme/WatchCommand.php
+++ b/src/Console/Command/Theme/WatchCommand.php
@@ -114,6 +114,6 @@ class WatchCommand extends AbstractCommand
         }
 
         $builder = $this->builderPool->getBuilder($themePath);
-        return $builder->watch($themePath, $this->io, $output, $isVerbose) ? self::SUCCESS : self::FAILURE;
+        return $builder->watch($themeCode, $themePath, $this->io, $output, $isVerbose) ? self::SUCCESS : self::FAILURE;
     }
 }

--- a/src/Service/StaticContentCleaner.php
+++ b/src/Service/StaticContentCleaner.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use Magento\Framework\App\State;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Service for automatically cleaning static content before theme builds
+ *
+ * In developer mode, Magento generates static files on-demand which can
+ * conflict with theme builder outputs. This service automatically detects
+ * and cleans such files before build/watch operations.
+ */
+class StaticContentCleaner
+{
+    public function __construct(
+        private readonly State $state,
+        private readonly ThemeCleaner $themeCleaner
+    ) {
+    }
+
+    /**
+     * Clean static content for a theme if in developer mode and files exist
+     *
+     * @param string $themeCode Theme code (e.g., "Magento/luma")
+     * @param SymfonyStyle $io Symfony style output
+     * @param OutputInterface $output Console output interface
+     * @param bool $isVerbose Whether to show verbose output
+     * @return bool True if cleaning was performed or not needed, false on error
+     */
+    public function cleanIfNeeded(
+        string $themeCode,
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $isVerbose
+    ): bool {
+        try {
+            // Only clean in developer mode
+            if ($this->state->getMode() !== State::MODE_DEVELOPER) {
+                return true;
+            }
+
+            // Check if static files exist for this theme
+            if (!$this->themeCleaner->hasStaticFiles($themeCode)) {
+                return true;
+            }
+
+            // Notify user
+            if ($isVerbose) {
+                $io->note(sprintf(
+                    "Developer mode detected: Cleaning existing static files for theme '%s'...",
+                    $themeCode
+                ));
+            }
+
+            // Clean the static files and preprocessed views using ThemeCleaner
+            $cleanedStatic = $this->themeCleaner->cleanPubStatic($themeCode, $io, false, $isVerbose);
+            $cleanedPreprocessed = $this->themeCleaner->cleanViewPreprocessed($themeCode, $io, false, $isVerbose);
+
+            return ($cleanedStatic > 0 || $cleanedPreprocessed > 0) || !$this->themeCleaner->hasStaticFiles($themeCode);
+        } catch (\Exception $e) {
+            $io->error('Failed to check/clean static content: ' . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/Service/ThemeBuilder/BuilderInterface.php
+++ b/src/Service/ThemeBuilder/BuilderInterface.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 interface BuilderInterface
 {
     public function detect(string $themePath): bool;
-    public function build(string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool;
+    public function build(string $themeCode, string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool;
     public function getName(): string;
     public function autoRepair(string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool;
-    public function watch(string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool;
+    public function watch(string $themeCode, string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool;
 }

--- a/src/Service/ThemeBuilder/HyvaThemes/Builder.php
+++ b/src/Service/ThemeBuilder/HyvaThemes/Builder.php
@@ -7,6 +7,7 @@ namespace OpenForgeProject\MageForge\Service\ThemeBuilder\HyvaThemes;
 use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Service\CacheCleaner;
+use OpenForgeProject\MageForge\Service\StaticContentCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentDeployer;
 use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,6 +21,7 @@ class Builder implements BuilderInterface
         private readonly Shell $shell,
         private readonly File $fileDriver,
         private readonly StaticContentDeployer $staticContentDeployer,
+        private readonly StaticContentCleaner $staticContentCleaner,
         private readonly CacheCleaner $cacheCleaner
     ) {
     }
@@ -54,9 +56,14 @@ class Builder implements BuilderInterface
         return false;
     }
 
-    public function build(string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool
+    public function build(string $themeCode, string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool
     {
         if (!$this->detect($themePath)) {
+            return false;
+        }
+
+        // Clean static content if in developer mode
+        if (!$this->staticContentCleaner->cleanIfNeeded($themeCode, $io, $output, $isVerbose)) {
             return false;
         }
 
@@ -73,7 +80,6 @@ class Builder implements BuilderInterface
         }
 
         // Deploy static content
-        $themeCode = basename($themePath);
         if (!$this->staticContentDeployer->deploy($themeCode, $io, $output, $isVerbose)) {
             return false;
         }
@@ -211,9 +217,14 @@ class Builder implements BuilderInterface
         chdir($currentDir);
     }
 
-    public function watch(string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool
+    public function watch(string $themeCode, string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool
     {
         if (!$this->detect($themePath)) {
+            return false;
+        }
+
+        // Clean static content if in developer mode
+        if (!$this->staticContentCleaner->cleanIfNeeded($themeCode, $io, $output, $isVerbose)) {
             return false;
         }
 
@@ -233,11 +244,11 @@ class Builder implements BuilderInterface
             } else {
                 $io->text('Starting watch mode... (use -v for verbose output)');
             }
-            
+
             chdir($tailwindPath);
             $exitCode = 0;
             passthru('npm run watch', $exitCode);
-            
+
             // Check if the command failed
             if ($exitCode !== 0) {
                 $io->error(sprintf('Watch mode exited with error code: %d', $exitCode));

--- a/src/Service/ThemeCleaner.php
+++ b/src/Service/ThemeCleaner.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Service for cleaning theme-related directories and cache
+ *
+ * Provides reusable methods for cleaning static content, preprocessed files,
+ * cache directories, and generated code related to themes.
+ */
+class ThemeCleaner
+{
+    public function __construct(
+        private readonly Filesystem $filesystem
+    ) {
+    }
+
+    /**
+     * Clean var/view_preprocessed directory for the theme
+     *
+     * @param string $themeCode Theme code (e.g., "Magento/luma")
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $dryRun If true, only show what would be cleaned
+     * @param bool $isVerbose Whether to show verbose output
+     * @return int Number of directories cleaned
+     */
+    public function cleanViewPreprocessed(
+        string $themeCode,
+        SymfonyStyle $io,
+        bool $dryRun = false,
+        bool $isVerbose = false
+    ): int {
+        $cleaned = 0;
+        $varDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        $themeParts = $this->parseThemeName($themeCode);
+        if ($themeParts === null) {
+            return 0;
+        }
+
+        [$vendor, $theme] = $themeParts;
+
+        if (!$varDirectory->isDirectory('view_preprocessed')) {
+            return 0;
+        }
+
+        $pathsToClean = [
+            sprintf('view_preprocessed/css/frontend/%s/%s', $vendor, $theme),
+            sprintf('view_preprocessed/source/frontend/%s/%s', $vendor, $theme),
+        ];
+
+        foreach ($pathsToClean as $path) {
+            if ($varDirectory->isDirectory($path)) {
+                try {
+                    if (!$dryRun) {
+                        $varDirectory->delete($path);
+                    }
+                    if ($isVerbose) {
+                        $action = $dryRun ? 'Would clean' : 'Cleaned';
+                        $io->writeln(sprintf('  <fg=green>✓</> %s: var/%s', $action, $path));
+                    }
+                    $cleaned++;
+                } catch (\Exception $e) {
+                    if ($isVerbose) {
+                        $io->writeln(sprintf(
+                            '  <fg=red>✗</> Failed to clean: var/%s - %s',
+                            $path,
+                            $e->getMessage()
+                        ));
+                    }
+                }
+            }
+        }
+
+        return $cleaned;
+    }
+
+    /**
+     * Clean pub/static directory for the theme
+     *
+     * @param string $themeCode Theme code (e.g., "Magento/luma")
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $dryRun If true, only show what would be cleaned
+     * @param bool $isVerbose Whether to show verbose output
+     * @return int Number of directories cleaned
+     */
+    public function cleanPubStatic(
+        string $themeCode,
+        SymfonyStyle $io,
+        bool $dryRun = false,
+        bool $isVerbose = false
+    ): int {
+        $cleaned = 0;
+        $staticDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::STATIC_VIEW);
+
+        $themeParts = $this->parseThemeName($themeCode);
+        if ($themeParts === null) {
+            return 0;
+        }
+
+        [$vendor, $theme] = $themeParts;
+
+        if (!$staticDirectory->isDirectory('frontend')) {
+            return 0;
+        }
+
+        $pathToClean = sprintf('frontend/%s/%s', $vendor, $theme);
+
+        if ($staticDirectory->isDirectory($pathToClean)) {
+            try {
+                if (!$dryRun) {
+                    $staticDirectory->delete($pathToClean);
+                }
+                if ($isVerbose) {
+                    $action = $dryRun ? 'Would clean' : 'Cleaned';
+                    $io->writeln(sprintf('  <fg=green>✓</> %s: pub/static/%s', $action, $pathToClean));
+                }
+                $cleaned++;
+            } catch (\Exception $e) {
+                if ($isVerbose) {
+                    $io->writeln(sprintf(
+                        '  <fg=red>✗</> Failed to clean: pub/static/%s - %s',
+                        $pathToClean,
+                        $e->getMessage()
+                    ));
+                }
+            }
+        }
+
+        return $cleaned;
+    }
+
+    /**
+     * Clean var/page_cache directory
+     *
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $dryRun If true, only show what would be cleaned
+     * @param bool $isVerbose Whether to show verbose output
+     * @return int Number of directories cleaned
+     */
+    public function cleanPageCache(
+        SymfonyStyle $io,
+        bool $dryRun = false,
+        bool $isVerbose = false
+    ): int {
+        $cleaned = 0;
+        $varDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        if ($varDirectory->isDirectory('page_cache')) {
+            try {
+                if (!$dryRun) {
+                    $varDirectory->delete('page_cache');
+                }
+                if ($isVerbose) {
+                    $action = $dryRun ? 'Would clean' : 'Cleaned';
+                    $io->writeln(sprintf('  <fg=green>✓</> %s: var/page_cache', $action));
+                }
+                $cleaned++;
+            } catch (\Exception $e) {
+                if ($isVerbose) {
+                    $io->writeln(sprintf(
+                        '  <fg=red>✗</> Failed to clean: var/page_cache - %s',
+                        $e->getMessage()
+                    ));
+                }
+            }
+        }
+
+        return $cleaned;
+    }
+
+    /**
+     * Clean var/tmp directory
+     *
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $dryRun If true, only show what would be cleaned
+     * @param bool $isVerbose Whether to show verbose output
+     * @return int Number of directories cleaned
+     */
+    public function cleanVarTmp(
+        SymfonyStyle $io,
+        bool $dryRun = false,
+        bool $isVerbose = false
+    ): int {
+        $cleaned = 0;
+        $varDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        if ($varDirectory->isDirectory('tmp')) {
+            try {
+                if (!$dryRun) {
+                    $varDirectory->delete('tmp');
+                }
+                if ($isVerbose) {
+                    $action = $dryRun ? 'Would clean' : 'Cleaned';
+                    $io->writeln(sprintf('  <fg=green>✓</> %s: var/tmp', $action));
+                }
+                $cleaned++;
+            } catch (\Exception $e) {
+                if ($isVerbose) {
+                    $io->writeln(sprintf(
+                        '  <fg=red>✗</> Failed to clean: var/tmp - %s',
+                        $e->getMessage()
+                    ));
+                }
+            }
+        }
+
+        return $cleaned;
+    }
+
+    /**
+     * Clean generated directory
+     *
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $dryRun If true, only show what would be cleaned
+     * @param bool $isVerbose Whether to show verbose output
+     * @return int Number of directories cleaned
+     */
+    public function cleanGenerated(
+        SymfonyStyle $io,
+        bool $dryRun = false,
+        bool $isVerbose = false
+    ): int {
+        $cleaned = 0;
+        $generatedDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::GENERATED);
+
+        try {
+            $deletedCount = 0;
+
+            if ($generatedDirectory->isDirectory('code')) {
+                try {
+                    if (!$dryRun) {
+                        $generatedDirectory->delete('code');
+                    }
+                    $deletedCount++;
+                } catch (\Exception $e) {
+                    if ($isVerbose) {
+                        $io->writeln(sprintf(
+                            '  <fg=red>✗</> Failed to clean: generated/code - %s',
+                            $e->getMessage()
+                        ));
+                    }
+                }
+            }
+
+            if ($generatedDirectory->isDirectory('metadata')) {
+                try {
+                    if (!$dryRun) {
+                        $generatedDirectory->delete('metadata');
+                    }
+                    $deletedCount++;
+                } catch (\Exception $e) {
+                    if ($isVerbose) {
+                        $io->writeln(sprintf(
+                            '  <fg=red>✗</> Failed to clean: generated/metadata - %s',
+                            $e->getMessage()
+                        ));
+                    }
+                }
+            }
+
+            if ($deletedCount > 0) {
+                if ($isVerbose) {
+                    $action = $dryRun ? 'Would clean' : 'Cleaned';
+                    $io->writeln(sprintf('  <fg=green>✓</> %s: generated/*', $action));
+                }
+                $cleaned++;
+            }
+        } catch (\Exception $e) {
+            if ($isVerbose) {
+                $io->writeln(sprintf(
+                    '  <fg=red>✗</> Failed to clean: generated - %s',
+                    $e->getMessage()
+                ));
+            }
+        }
+
+        return $cleaned;
+    }
+
+    /**
+     * Check if static files exist for the theme in pub/static
+     *
+     * @param string $themeCode Theme code (e.g., "Magento/luma")
+     * @return bool True if static files exist
+     */
+    public function hasStaticFiles(string $themeCode): bool
+    {
+        $themeParts = $this->parseThemeName($themeCode);
+        if ($themeParts === null) {
+            return false;
+        }
+
+        [$vendor, $theme] = $themeParts;
+        $staticDirectory = $this->filesystem->getDirectoryRead(DirectoryList::STATIC_VIEW);
+
+        $themePath = sprintf('frontend/%s/%s', $vendor, $theme);
+        return $staticDirectory->isDirectory($themePath);
+    }
+
+    /**
+     * Parse theme name into vendor and theme parts
+     *
+     * @param string $themeCode Theme code (e.g., "Magento/luma")
+     * @return array{0: string, 1: string}|null Array with [vendor, theme] or null if invalid
+     */
+    private function parseThemeName(string $themeCode): ?array
+    {
+        $themeParts = explode('/', $themeCode);
+        if (count($themeParts) !== 2) {
+            return null;
+        }
+
+        return $themeParts;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -47,4 +47,11 @@
                   <argument name="themeList" xsi:type="object">OpenForgeProject\MageForge\Model\ThemeList</argument>
             </arguments>
       </type>
+
+      <!-- Configure CleanCommand with ThemeCleaner -->
+      <type name="OpenForgeProject\MageForge\Console\Command\Theme\CleanCommand">
+            <arguments>
+                  <argument name="themeCleaner" xsi:type="object">OpenForgeProject\MageForge\Service\ThemeCleaner</argument>
+            </arguments>
+      </type>
 </config>


### PR DESCRIPTION
## Automatic Static File Cleaning in Developer Mode


### Problem
In developer mode, Magento generates static files on-demand which can conflict with theme builder outputs. This leads to inconsistent styling and cached assets that don't reflect the latest theme changes.

### Solution
Implemented automatic cleaning of theme-specific static files before build/watch operations when running in developer mode.

**Key Changes:**
- **ThemeCleaner Service**: Centralized service for all theme cleaning operations (eliminates code duplication)
- **StaticContentCleaner Service**: Detects developer mode and automatically cleans:
  - `pub/static/frontend/{Vendor}/{theme}/`
  - `var/view_preprocessed/css/frontend/{Vendor}/{theme}/`
  - `var/view_preprocessed/source/frontend/{Vendor}/{theme}/`
- **Builder Integration**: All three builders (HyvaThemes, MagentoStandard, TailwindCSS) now use StaticContentCleaner
- **CleanCommand Refactoring**: Refactored to use ThemeCleaner service (~210 lines of duplicate code removed)

**Behavior:**
- ✅ Automatic cleaning **only** in developer mode
- ✅ Silent in normal mode, verbose output with `-v` flag
- ✅ Works for both `build` and `watch` commands
- ✅ Manual cleaning still available via `mageforge:theme:clean`