### PR TITLE
feat: implement SymlinkCleaner service and integrate into theme builders #88

### DIFF
--- a/src/Service/SymlinkCleaner.php
+++ b/src/Service/SymlinkCleaner.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use Magento\Framework\App\State;
+use Magento\Framework\Filesystem\Driver\File;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Service for cleaning symlinks in theme CSS directories
+ *
+ * In developer mode, symlinks in {theme}/web/css/ can cause issues during
+ * the build process. This service detects and removes all symlinks before
+ * the build starts to ensure a clean workflow.
+ */
+class SymlinkCleaner
+{
+    public function __construct(
+        private readonly File $fileDriver,
+        private readonly State $state
+    ) {
+    }
+
+    /**
+     * Remove all symlinks from {theme}/web/css/ directory in developer mode
+     *
+     * @param string $themePath Path to theme directory
+     * @param SymfonyStyle $io Symfony style output
+     * @param bool $isVerbose Whether to show verbose output
+     * @return bool True on success or if no action needed, false on error
+     */
+    public function cleanSymlinks(
+        string $themePath,
+        SymfonyStyle $io,
+        bool $isVerbose
+    ): bool {
+        try {
+            // Only clean symlinks in developer mode
+            if ($this->state->getMode() !== State::MODE_DEVELOPER) {
+                return true;
+            }
+
+            $cssPath = rtrim($themePath, '/') . '/web/css';
+
+            // Nothing to clean if directory doesn't exist
+            if (!$this->fileDriver->isDirectory($cssPath)) {
+                return true;
+            }
+
+            $items = $this->fileDriver->readDirectory($cssPath);
+            $deletedCount = 0;
+
+            foreach ($items as $item) {
+                // Check if item is a symlink
+                if (is_link($item)) {
+                    $this->fileDriver->deleteFile($item);
+                    $deletedCount++;
+
+                    if ($isVerbose) {
+                        $io->writeln(sprintf(
+                            '  <fg=yellow>⚠</> Removed symlink: %s',
+                            basename($item)
+                        ));
+                    }
+                }
+            }
+
+            if ($deletedCount > 0 && $isVerbose) {
+                $io->success(sprintf(
+                    'Removed %d symlink(s) from web/css/',
+                    $deletedCount
+                ));
+            }
+
+            return true;
+        } catch (\Exception $e) {
+            // Don't fail the build process if symlink cleanup fails
+            // Just warn the user and continue
+            if ($isVerbose) {
+                $io->warning(sprintf(
+                    'Could not clean symlinks: %s',
+                    $e->getMessage()
+                ));
+            }
+            return true;
+        }
+    }
+}

--- a/src/Service/ThemeBuilder/HyvaThemes/Builder.php
+++ b/src/Service/ThemeBuilder/HyvaThemes/Builder.php
@@ -9,6 +9,7 @@ use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Service\CacheCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentDeployer;
+use OpenForgeProject\MageForge\Service\SymlinkCleaner;
 use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -22,7 +23,8 @@ class Builder implements BuilderInterface
         private readonly File $fileDriver,
         private readonly StaticContentDeployer $staticContentDeployer,
         private readonly StaticContentCleaner $staticContentCleaner,
-        private readonly CacheCleaner $cacheCleaner
+        private readonly CacheCleaner $cacheCleaner,
+        private readonly SymlinkCleaner $symlinkCleaner
     ) {
     }
 
@@ -68,6 +70,11 @@ class Builder implements BuilderInterface
         }
 
         if (!$this->autoRepair($themePath, $io, $output, $isVerbose)) {
+            return false;
+        }
+
+        // Clean symlinks in web/css/ directory before build
+        if (!$this->symlinkCleaner->cleanSymlinks($themePath, $io, $isVerbose)) {
             return false;
         }
 

--- a/src/Service/ThemeBuilder/MagentoStandard/Builder.php
+++ b/src/Service/ThemeBuilder/MagentoStandard/Builder.php
@@ -9,6 +9,7 @@ use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Service\CacheCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentDeployer;
+use OpenForgeProject\MageForge\Service\SymlinkCleaner;
 use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -22,7 +23,8 @@ class Builder implements BuilderInterface
         private readonly File $fileDriver,
         private readonly StaticContentDeployer $staticContentDeployer,
         private readonly StaticContentCleaner $staticContentCleaner,
-        private readonly CacheCleaner $cacheCleaner
+        private readonly CacheCleaner $cacheCleaner,
+        private readonly SymlinkCleaner $symlinkCleaner
     ) {
     }
 
@@ -49,6 +51,11 @@ class Builder implements BuilderInterface
         }
 
         if (!$this->autoRepair($themePath, $io, $output, $isVerbose)) {
+            return false;
+        }
+
+        // Clean symlinks in web/css/ directory before build
+        if (!$this->symlinkCleaner->cleanSymlinks($themePath, $io, $isVerbose)) {
             return false;
         }
 

--- a/src/Service/ThemeBuilder/TailwindCSS/Builder.php
+++ b/src/Service/ThemeBuilder/TailwindCSS/Builder.php
@@ -9,6 +9,7 @@ use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Service\CacheCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentDeployer;
+use OpenForgeProject\MageForge\Service\SymlinkCleaner;
 use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -22,7 +23,8 @@ class Builder implements BuilderInterface
         private readonly File $fileDriver,
         private readonly StaticContentDeployer $staticContentDeployer,
         private readonly StaticContentCleaner $staticContentCleaner,
-        private readonly CacheCleaner $cacheCleaner
+        private readonly CacheCleaner $cacheCleaner,
+        private readonly SymlinkCleaner $symlinkCleaner
     ) {
     }
 
@@ -68,6 +70,11 @@ class Builder implements BuilderInterface
         }
 
         if (!$this->autoRepair($themePath, $io, $output, $isVerbose)) {
+            return false;
+        }
+
+        // Clean symlinks in web/css/ directory before build
+        if (!$this->symlinkCleaner->cleanSymlinks($themePath, $io, $isVerbose)) {
             return false;
         }
 

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -56,4 +56,12 @@
                   <argument name="themeCleaner" xsi:type="object">OpenForgeProject\MageForge\Service\ThemeCleaner</argument>
             </arguments>
       </type>
+
+      <!-- Configure SymlinkCleaner Service -->
+      <type name="OpenForgeProject\MageForge\Service\SymlinkCleaner">
+            <arguments>
+                  <argument name="fileDriver" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+                  <argument name="state" xsi:type="object">Magento\Framework\App\State</argument>
+            </arguments>
+      </type>
 </config>


### PR DESCRIPTION
## Fix: Clean symlinks in theme CSS directory before build

Fixes #88

### Problem

In developer mode, symlinks in the `{theme}/web/css/` directory (e.g., `styles.css`) were not consistently overwritten during the build process. This could lead to outdated CSS being served or build failures, as the symlinks pointed to stale file locations after regeneration.

### Solution

Introduced automatic symlink cleanup before theme builds:
- New `SymlinkCleaner` service scans `{theme}/web/css/` directory
- Detects and removes **all** symlinks (not just `styles.css`)
- Only runs in **developer mode** (production unaffected)
- Integrated into all three theme builders: HyvaThemes, TailwindCSS, MagentoStandard

### Changes

**New Service:**
- `src/Service/SymlinkCleaner.php` - Handles symlink detection and cleanup

**Updated Builders:**
- `src/Service/ThemeBuilder/HyvaThemes/Builder.php` - Added symlink cleanup before build
- `src/Service/ThemeBuilder/TailwindCSS/Builder.php` - Added symlink cleanup before build  
- `src/Service/ThemeBuilder/MagentoStandard/Builder.php` - Added symlink cleanup before build

**Configuration:**
- `src/etc/di.xml` - Registered `SymlinkCleaner` service with DI

### Implementation Details

**SymlinkCleaner Service:**
- Uses `Magento\Framework\App\State` to detect developer mode
- Scans directory with `FileDriver::readDirectory()`
- Identifies symlinks via PHP's `is_link()`
- Removes with `FileDriver::deleteFile()`
- Executes after `autoRepair()`, before build commands
- Fails gracefully with warning (doesn't abort build on errors)

**Verbose Mode Output:**