### PR TITLE
feat: add NodePackageManager service for npm dependency management

### DIFF
--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use Magento\Framework\Filesystem\Driver\File as FileDriver;
+use Magento\Framework\Shell;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Service for managing Node.js package installation and updates
+ */
+class NodePackageManager
+{
+    public function __construct(
+        private readonly Shell $shell,
+        private readonly FileDriver $fileDriver
+    ) {}
+
+    /**
+     * Install node modules in the specified directory
+     *
+     * Uses npm ci if package-lock.json exists, otherwise falls back to npm install
+     */
+    public function installNodeModules(string $path, SymfonyStyle $io, bool $isVerbose): bool
+    {
+        $currentDir = getcwd();
+        chdir($path);
+
+        try {
+            if ($this->fileDriver->isExists($path . '/package-lock.json')) {
+                $this->shell->execute('npm ci --quiet');
+            } else {
+                if ($isVerbose) {
+                    $io->warning('No package-lock.json found, running npm install...');
+                }
+                $this->shell->execute('npm install --quiet');
+            }
+
+            if ($isVerbose) {
+                $io->success('Node modules installed successfully.');
+            }
+
+            chdir($currentDir);
+            return true;
+        } catch (\Exception $e) {
+            $io->error('Failed to install node modules: ' . $e->getMessage());
+            chdir($currentDir);
+            return false;
+        }
+    }
+
+    /**
+     * Check for outdated npm packages and report them
+     *
+     * Note: npm outdated returns non-zero exit code when packages are outdated,
+     * so exceptions are caught and ignored
+     */
+    public function checkOutdatedPackages(string $path, SymfonyStyle $io): void
+    {
+        $currentDir = getcwd();
+        chdir($path);
+
+        try {
+            $outdated = $this->shell->execute('npm outdated --json');
+            if ($outdated) {
+                $io->warning('Outdated packages found:');
+                $io->writeln($outdated);
+            }
+        } catch (\Exception $e) {
+            // Ignore errors from npm outdated as it returns non-zero when packages are outdated
+        }
+
+        chdir($currentDir);
+    }
+}

--- a/src/Service/ThemeBuilder/HyvaThemes/Builder.php
+++ b/src/Service/ThemeBuilder/HyvaThemes/Builder.php
@@ -7,6 +7,7 @@ namespace OpenForgeProject\MageForge\Service\ThemeBuilder\HyvaThemes;
 use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\Shell;
 use OpenForgeProject\MageForge\Service\CacheCleaner;
+use OpenForgeProject\MageForge\Service\NodePackageManager;
 use OpenForgeProject\MageForge\Service\StaticContentCleaner;
 use OpenForgeProject\MageForge\Service\StaticContentDeployer;
 use OpenForgeProject\MageForge\Service\SymlinkCleaner;
@@ -24,7 +25,8 @@ class Builder implements BuilderInterface
         private readonly StaticContentDeployer $staticContentDeployer,
         private readonly StaticContentCleaner $staticContentCleaner,
         private readonly CacheCleaner $cacheCleaner,
-        private readonly SymlinkCleaner $symlinkCleaner
+        private readonly SymlinkCleaner $symlinkCleaner,
+        private readonly NodePackageManager $nodePackageManager
     ) {
     }
 
@@ -155,73 +157,20 @@ class Builder implements BuilderInterface
 
         // Check for node_modules directory
         if (!$this->fileDriver->isDirectory($tailwindPath . '/node_modules')) {
-            if (!$this->installNodeModules($tailwindPath, $io, $isVerbose)) {
+            if ($isVerbose) {
+                $io->warning('Node modules not found in tailwind directory. Installing...');
+            }
+            if (!$this->nodePackageManager->installNodeModules($tailwindPath, $io, $isVerbose)) {
                 return false;
             }
         }
 
         // Check for outdated packages
         if ($isVerbose) {
-            $this->checkOutdatedPackages($tailwindPath, $io);
+            $this->nodePackageManager->checkOutdatedPackages($tailwindPath, $io);
         }
 
         return true;
-    }
-
-    /**
-     * Install Node modules in the tailwind directory
-     */
-    private function installNodeModules(string $tailwindPath, SymfonyStyle $io, bool $isVerbose): bool
-    {
-        if ($isVerbose) {
-            $io->warning('Node modules not found in tailwind directory. Running npm ci...');
-        }
-
-        $currentDir = getcwd();
-        chdir($tailwindPath);
-
-        try {
-            if ($this->fileDriver->isExists($tailwindPath . '/package-lock.json')) {
-                $this->shell->execute('npm ci --quiet');
-            } else {
-                if ($isVerbose) {
-                    $io->warning('No package-lock.json found, running npm install...');
-                }
-                $this->shell->execute('npm install --quiet');
-            }
-
-            if ($isVerbose) {
-                $io->success('Node modules installed successfully.');
-            }
-
-            chdir($currentDir);
-            return true;
-        } catch (\Exception $e) {
-            $io->error('Failed to install node modules: ' . $e->getMessage());
-            chdir($currentDir);
-            return false;
-        }
-    }
-
-    /**
-     * Check for outdated npm packages and report them
-     */
-    private function checkOutdatedPackages(string $tailwindPath, SymfonyStyle $io): void
-    {
-        $currentDir = getcwd();
-        chdir($tailwindPath);
-
-        try {
-            $outdated = $this->shell->execute('npm outdated --json');
-            if ($outdated) {
-                $io->warning('Outdated packages found:');
-                $io->writeln($outdated);
-            }
-        } catch (\Exception $e) {
-            // Ignore errors from npm outdated as it returns non-zero when packages are outdated
-        }
-
-        chdir($currentDir);
     }
 
     public function watch(string $themeCode, string $themePath, SymfonyStyle $io, OutputInterface $output, bool $isVerbose): bool

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -64,4 +64,12 @@
                   <argument name="state" xsi:type="object">Magento\Framework\App\State</argument>
             </arguments>
       </type>
+
+      <!-- Configure NodePackageManager Service -->
+      <type name="OpenForgeProject\MageForge\Service\NodePackageManager">
+            <arguments>
+                  <argument name="shell" xsi:type="object">Magento\Framework\Shell</argument>
+                  <argument name="fileDriver" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+            </arguments>
+      </type>
 </config>


### PR DESCRIPTION
## Refactor: Extract npm package management to reusable service

Fixes #90

### Problem

The `HyvaThemes` and `TailwindCSS` builders contained identical duplicate code for npm package installation and outdated package checking (~90 lines total duplication). This violated the DRY principle and made maintenance difficult.

**CodeFactor warnings:**
- Duplicate code in `installNodeModules()` method (lines 180-206 in HyvaThemes, 151-177 in TailwindCSS)
- Duplicate code in `checkOutdatedPackages()` method (lines 213-224 in HyvaThemes, 184-191 in TailwindCSS)

### Solution

Created a new `NodePackageManager` service that centralises npm-related operations:

- **npm ci/install**: Automatically uses `npm ci` when `package-lock.json` exists, falls back to `npm install` otherwise
- **Outdated check**: Reports outdated packages with `npm outdated --json`
- **Error handling**: Graceful failure handling with proper chdir management

### Changes

#### New files
- `src/Service/NodePackageManager.php` (79 lines)

#### Modified files
- `src/Service/ThemeBuilder/HyvaThemes/Builder.php` (~45 lines removed)
- `src/Service/ThemeBuilder/TailwindCSS/Builder.php` (~45 lines removed)
- `src/etc/di.xml` (NodePackageManager service configuration)

#### Code improvements
- **DRY compliance**: Eliminated ~90 lines of duplicate code
- **Maintainability**: Single source of truth for npm operations
- **Testability**: Isolated service can be unit tested independently
- **Reusability**: Can easily be used in future builders
- **PSR-12/PER-CS-2.0**: Strict types, readonly properties, constructor promotion

### Testing

- ✅ `setup:upgrade` successful
- ✅ `setup:di:compile` successful  
- ✅ PHP syntax validation passed
- ✅ `mageforge:theme:build Hyva/default -v` works correctly
- ✅ NodePackageManager correctly installed in both builders

### Migration notes

No breaking changes. Existing theme builds continue to work identically. The refactoring is purely internal.

---

**Related:**
- Issue #88 (SymlinkCleaner) - This PR builds on similar service extraction patterns