### PR TITLE
fix(phpcs): remove unnecessary command

### DIFF
--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -15,5 +15,4 @@ if [[ ! -d ${TEMP_DIR} ]]; then
 fi
 
 # Run PHPCS
-cd magento/vendor/mageforge/base || exit 1
 "${PHPCS_BIN}" -p -s --standard=Magento2 src/


### PR DESCRIPTION
This pull request makes a minor change to the `.ddev/commands/web/phpcs` script, specifically removing the line that changes the directory to `magento/vendor/mageforge/base` before running the PHPCS command. This simplifies the script and ensures that PHPCS is run from the current working directory.