### PR TITLE
ci: workflow permissions

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   functional-tests:
     name: Functional Tests (Magento 2.4.8, PHP 8.4)


### PR DESCRIPTION
Potential fix for [https://github.com/OpenForgeProject/mageforge/security/code-scanning/4](https://github.com/OpenForgeProject/mageforge/security/code-scanning/4)

In general, fix this by explicitly defining a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes required. Place it either at the top level of the workflow (applies to all jobs) or under the specific job (`functional-tests`). Since this workflow has only one job and no steps need to write to the repository or PRs, the minimal safe configuration is `contents: read`. If you’re confident the job does not need the token at all, you could set `permissions: {}` to fully disable it, but to align with the CodeQL suggestion and common practice, using `contents: read` is appropriate.

Concretely, edit `.github/workflows/functional-tests.yml` and insert a top‑level `permissions:` block after the `name:` and `on:` sections and before `jobs:`. The block should be:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or dependencies are required; this is a pure YAML configuration change to the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
