### PR TITLE
fix: update head-branch patterns and file globbing in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,22 +3,22 @@ Documentation:
   - any-glob-to-any-file: '**/*.md'
 
 Feature:
- - head-branch: ['^add:']
+ - head-branch: ['add:*']
 
 Fix:
- - head-branch: ['^fix:']
+ - head-branch: ['fix:*']
 
 Next-Release:
- - head-branch: ['^chore: Next Release']
+ - head-branch: ['chore: release*', 'release-please*']
 
 Command:
 - changed-files:
-  - any-glob-to-any-file: 'src/Console/Command/*'
+  - any-glob-to-any-file: 'src/Console/Command/**'
 
 Frontend:
 - changed-files:
-  - any-glob-to-any-file: 'src/view/frontend/*'
+  - any-glob-to-any-file: 'src/view/frontend/**'
 
-ThemeBuilder:
+Theme-Builder:
 - changed-files:
-  - any-glob-to-any-file: 'src/src/Service/ThemeBuilder/*'
+  - any-glob-to-any-file: 'src/Service/ThemeBuilder/**'


### PR DESCRIPTION
This pull request updates the `.github/labeler.yml` configuration to improve label assignment based on branch naming conventions and file path patterns. The changes enhance the flexibility and accuracy of automated labeling for pull requests.

Labeling rules improvements:

* Updated branch pattern matching for `Feature`, `Fix`, and `Next-Release` labels to use wildcards (e.g., `'add:*'`, `'fix:*'`, and expanded `Next-Release` to include more patterns) for broader and more accurate coverage.
* Expanded file path globs for `Command`, `Frontend`, and `Theme-Builder` labels to use recursive matching (`**`) for better detection of changes in nested directories.
* Corrected the label name from `ThemeBuilder` to `Theme-Builder` for consistency.