### PR TITLE
fix: improve node module installation fallback logic - Fix Issue #106

### DIFF
--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -35,7 +35,14 @@ class NodePackageManager
 
         try {
             if ($this->fileDriver->isExists($path . '/package-lock.json')) {
-                $this->shell->execute('npm ci --quiet');
+                try {
+                    $this->shell->execute('npm ci --quiet');
+                } catch (\Exception $e) {
+                    if ($isVerbose) {
+                        $io->warning('npm ci failed, falling back to npm install...');
+                    }
+                    $this->shell->execute('npm install --quiet');
+                }
             } else {
                 if ($isVerbose) {
                     $io->warning('No package-lock.json found, running npm install...');
@@ -74,7 +81,7 @@ class NodePackageManager
         }
 
         if (!$this->fileDriver->isExists($path . '/package-lock.json')) {
-            return true;
+            return false;
         }
 
         $currentDir = getcwd();


### PR DESCRIPTION
This pull request refactors how Node.js dependencies are managed and checked within the Magento theme builder, improving reliability and maintainability. The changes centralize node module management into a dedicated service, enhance the detection of out-of-sync dependencies, and simplify the builder logic by removing duplicate code.

Node modules management improvements:
* Refactored node module installation logic out of the `Builder` class and into the `NodePackageManager` service, removing the private `installNodeModulesIfMissing` method and updating all relevant code paths to use the new service. [[1]](diffhunk://#diff-b3bbe1d78af130c6ae022985d2a80623d2d11dc67cf37dd7bf4ed6bf5f21b0f7L101-R113) [[2]](diffhunk://#diff-b3bbe1d78af130c6ae022985d2a80623d2d11dc67cf37dd7bf4ed6bf5f21b0f7L119-L151) [[3]](diffhunk://#diff-b3bbe1d78af130c6ae022985d2a80623d2d11dc67cf37dd7bf4ed6bf5f21b0f7L212-L216)
* Updated the constructor of the `Builder` class to inject the `NodePackageManager` dependency. [[1]](diffhunk://#diff-b3bbe1d78af130c6ae022985d2a80623d2d11dc67cf37dd7bf4ed6bf5f21b0f7R10) [[2]](diffhunk://#diff-b3bbe1d78af130c6ae022985d2a80623d2d11dc67cf37dd7bf4ed6bf5f21b0f7L27-R29)

Dependency synchronization checks:
* Improved the `isNodeModulesInSync` method in `NodePackageManager` to return `false` when `package-lock.json` is missing, ensuring that missing lock files are treated as out-of-sync.
* Enhanced the `installNodeModules` method to attempt `npm install` as a fallback if `npm ci` fails, providing better resilience during installation.

Fix Issue #106 