### PR TITLE
fix: update phpstan level to 7 and improve error handling

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-    level: 6
+    level: 7
     paths:
         - src

--- a/src/Console/Command/System/CheckCommand.php
+++ b/src/Console/Command/System/CheckCommand.php
@@ -52,6 +52,7 @@ class CheckCommand extends AbstractCommand
         $dbType = $this->getDatabaseType();
         $osInfo = $this->getShortOsInfo();
         $magentoVersion = $this->productMetadata->getVersion();
+        /** @var string $latestLtsNodeVersion */
         $latestLtsNodeVersion = $this->escaper->escapeHtml($this->getLatestLtsNodeVersion());
         $composerVersion = $this->getComposerVersion();
         $npmVersion = $this->getNpmVersion();
@@ -227,9 +228,14 @@ class CheckCommand extends AbstractCommand
 
             $dsn = "mysql:host=$host;port=$port";
             $pdo = new \PDO($dsn, $user, $pass, [\PDO::ATTR_TIMEOUT => 1]);
-            $version = $pdo->query('SELECT VERSION()')->fetchColumn();
+            $stmt = $pdo->query('SELECT VERSION()');
+            if ($stmt === false) {
+                return null;
+            }
 
-            return !empty($version) ? $version : null;
+            $version = $stmt->fetchColumn();
+
+            return !empty($version) ? (string)$version : null;
         } catch (\Exception $e) {
             return null;
         }

--- a/src/Console/Command/Theme/TokensCommand.php
+++ b/src/Console/Command/Theme/TokensCommand.php
@@ -175,6 +175,10 @@ class TokensCommand extends AbstractCommand
         }
 
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            $this->io->error("Cannot determine current directory");
+            return false;
+        }
         chdir($tailwindPath);
 
         try {

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -105,6 +105,10 @@ class InspectorHints implements TemplateEngineInterface
         // JSON encode with proper escaping for HTML comments
         $jsonMetadata = json_encode($metadata, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
+        if ($jsonMetadata === false) {
+            return $html;
+        }
+
         // Escape any comment terminators in JSON to prevent breaking out of comment
         $jsonMetadata = str_replace('-->', '--&gt;', $jsonMetadata);
 
@@ -164,7 +168,7 @@ class InspectorHints implements TemplateEngineInterface
     {
         if (method_exists($block, 'getViewModel')) {
             $viewModel = $block->getViewModel();
-            if ($viewModel) {
+            if (is_object($viewModel)) {
                 return get_class($viewModel);
             }
         }

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -31,6 +31,11 @@ class NodePackageManager
     public function installNodeModules(string $path, SymfonyStyle $io, bool $isVerbose): bool
     {
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            $io->error('Cannot determine current directory');
+            return false;
+        }
+
         chdir($path);
 
         try {
@@ -85,6 +90,10 @@ class NodePackageManager
         }
 
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            return false;
+        }
+
         chdir($path);
 
         try {
@@ -107,6 +116,10 @@ class NodePackageManager
     public function checkOutdatedPackages(string $path, SymfonyStyle $io): void
     {
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            return;
+        }
+
         chdir($path);
 
         try {

--- a/src/Service/ThemeBuilder/HyvaThemes/Builder.php
+++ b/src/Service/ThemeBuilder/HyvaThemes/Builder.php
@@ -130,6 +130,10 @@ class Builder implements BuilderInterface
 
         // Change to tailwind directory and run build
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            $io->error('Cannot determine current directory');
+            return false;
+        }
         chdir($tailwindPath);
 
         try {

--- a/src/Service/ThemeBuilder/TailwindCSS/Builder.php
+++ b/src/Service/ThemeBuilder/TailwindCSS/Builder.php
@@ -89,6 +89,10 @@ class Builder implements BuilderInterface
 
         // Change to tailwind directory and run build
         $currentDir = getcwd();
+        if ($currentDir === false) {
+            $io->error('Cannot determine current directory');
+            return false;
+        }
         chdir($tailwindPath);
 
         try {


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on error handling for filesystem operations, type safety, and code robustness. The main changes ensure that failures to determine the current working directory (`getcwd()`) are handled gracefully, preventing potential runtime errors. Additionally, there are updates to type handling and configuration for static analysis.

**Error Handling Improvements**

* Added checks for `getcwd()` returning `false` in multiple places (`NodePackageManager`, `ThemeBuilder`, `TailwindCSS Builder`, and `TokensCommand`), with appropriate error messages and early returns to prevent further execution when the current directory cannot be determined. [[1]](diffhunk://#diff-3d5549134445295138d538803ac95594fff629d8975703ed18ce2e9a8356a0ebR34-R38) [[2]](diffhunk://#diff-3d5549134445295138d538803ac95594fff629d8975703ed18ce2e9a8356a0ebR93-R96) [[3]](diffhunk://#diff-3d5549134445295138d538803ac95594fff629d8975703ed18ce2e9a8356a0ebR119-R122) [[4]](diffhunk://#diff-527643adf1559dda9002569ca24f700e5e6fb4e82987f6f09ea804f6f6f134abR133-R136) [[5]](diffhunk://#diff-c0b49291fcbbc551e9315ad1eb5b737a9b236bb4462c24e6bf6ebc343680a7d2R92-R95) [[6]](diffhunk://#diff-980df1ffccde1f84cea928ad3319be76a21992355f89b12c5fa9f056a0d547ecR178-R181)

**Type Safety and Robustness**

* Improved type safety in `injectInspectorAttributes()` by checking for JSON encoding failures before proceeding, ensuring that invalid metadata does not break HTML output.
* Updated `getViewModel()` to check if the returned value is an object before calling `get_class()`, preventing potential errors if the value is not an object.
* Added a type hint for `$latestLtsNodeVersion` to clarify its expected type.
* Improved handling of PDO query results in `getMysqlVersionViaPdo()` by checking for query failure and ensuring the returned version is a string.

**Configuration Updates**

* Increased PHPStan static analysis level from 6 to 7 in `phpstan.neon`, enforcing stricter code checks.