### PR TITLE
fix: update phpstan level to 8 and improve commands

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-    level: 7
+    level: 8
     paths:
         - src

--- a/src/Console/Command/Dev/InspectorCommand.php
+++ b/src/Console/Command/Dev/InspectorCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenForgeProject\MageForge\Console\Command\Dev;
 
 use Magento\Framework\App\Cache\Manager as CacheManager;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
@@ -25,6 +26,7 @@ class InspectorCommand extends AbstractCommand
         private readonly WriterInterface $configWriter,
         private readonly State $state,
         private readonly CacheManager $cacheManager,
+        private readonly ScopeConfigInterface $scopeConfig,
         ?string $name = null
     ) {
         parent::__construct($name);
@@ -200,9 +202,7 @@ HELP
     private function isInspectorEnabled(): bool
     {
         try {
-            $scopeConfig = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Framework\App\Config\ScopeConfigInterface::class);
-            return $scopeConfig->isSetFlag(self::XML_PATH_INSPECTOR_ENABLED);
+            return $this->scopeConfig->isSetFlag(self::XML_PATH_INSPECTOR_ENABLED);
         } catch (\Exception $e) {
             return false;
         }

--- a/src/Console/Command/System/CheckCommand.php
+++ b/src/Console/Command/System/CheckCommand.php
@@ -6,8 +6,10 @@ namespace OpenForgeProject\MageForge\Console\Command\System;
 
 use Composer\Semver\Comparator;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Escaper;
+use Magento\Framework\HTTP\ClientFactory;
 use OpenForgeProject\MageForge\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,6 +29,8 @@ class CheckCommand extends AbstractCommand
     public function __construct(
         private readonly ProductMetadataInterface $productMetadata,
         private readonly Escaper $escaper,
+        private readonly ResourceConnection $resourceConnection,
+        private readonly ClientFactory $httpClientFactory
     ) {
         parent::__construct();
     }
@@ -181,9 +185,7 @@ class CheckCommand extends AbstractCommand
     private function getMysqlVersionViaMagento(): ?string
     {
         try {
-            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-            $resource = $objectManager->get(\Magento\Framework\App\ResourceConnection::class);
-            $connection = $resource->getConnection();
+            $connection = $this->resourceConnection->getConnection();
             $version = $connection->fetchOne('SELECT VERSION()');
 
             return !empty($version) ? $version : null;
@@ -584,9 +586,7 @@ class CheckCommand extends AbstractCommand
     private function tryMagentoHttpClient(string $url): ?array
     {
         try {
-            $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-            $httpClientFactory = $objectManager->get(\Magento\Framework\HTTP\ClientFactory::class);
-            $httpClient = $httpClientFactory->create();
+            $httpClient = $this->httpClientFactory->create();
             $httpClient->setTimeout(2);
             $httpClient->get($url);
 

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -262,6 +262,11 @@ class BuildCommand extends AbstractCommand
     ): bool {
         $themePath = $this->themePath->getPath($themeCode);
 
+        if ($themePath === null) {
+            $io->error("Could not find path for theme $themeCode.");
+            return false;
+        }
+
         // Find appropriate builder
         $builder = $this->builderPool->getBuilder($themePath);
         if ($builder === null) {
@@ -447,6 +452,9 @@ class BuildCommand extends AbstractCommand
     private function sanitizeTermValue(string $value): ?string
     {
         $sanitized = preg_replace('/[^a-zA-Z0-9\-]/', '', $value);
+        if ($sanitized === null) {
+            return null;
+        }
         return (strlen($sanitized) > 0 && strlen($sanitized) <= 50) ? $sanitized : null;
     }
 
@@ -465,6 +473,9 @@ class BuildCommand extends AbstractCommand
     private function sanitizeAlphanumericValue(string $value): ?string
     {
         $sanitized = preg_replace('/[^\w\-.]/', '', $value);
+        if ($sanitized === null) {
+            return null;
+        }
         return (strlen($sanitized) > 0 && strlen($sanitized) <= 255) ? $sanitized : null;
     }
 

--- a/src/Console/Command/Theme/CleanCommand.php
+++ b/src/Console/Command/Theme/CleanCommand.php
@@ -599,6 +599,9 @@ class CleanCommand extends AbstractCommand
     private function sanitizeTermValue(string $value): ?string
     {
         $sanitized = preg_replace('/[^a-zA-Z0-9\-]/', '', $value);
+        if ($sanitized === null) {
+            return null;
+        }
         return (strlen($sanitized) > 0 && strlen($sanitized) <= 50) ? $sanitized : null;
     }
 
@@ -617,6 +620,9 @@ class CleanCommand extends AbstractCommand
     private function sanitizeAlphanumericValue(string $value): ?string
     {
         $sanitized = preg_replace('/[^\w\-.]/', '', $value);
+        if ($sanitized === null) {
+            return null;
+        }
         return (strlen($sanitized) > 0 && strlen($sanitized) <= 255) ? $sanitized : null;
     }
 

--- a/src/Console/Command/Theme/WatchCommand.php
+++ b/src/Console/Command/Theme/WatchCommand.php
@@ -114,6 +114,11 @@ class WatchCommand extends AbstractCommand
         }
 
         $builder = $this->builderPool->getBuilder($themePath);
+        if ($builder === null) {
+            $this->io->error("No suitable builder found for theme $themeCode.");
+            return self::FAILURE;
+        }
+
         return $builder->watch($themeCode, $themePath, $this->io, $output, $isVerbose) ? self::SUCCESS : self::FAILURE;
     }
 }


### PR DESCRIPTION
This pull request improves dependency injection usage, error handling, and input sanitization across several console commands. The main focus is on replacing direct usage of Magento's ObjectManager with constructor-injected dependencies, which enhances code testability and maintainability. Additionally, it improves validation and error reporting in theme-related commands.

**Dependency Injection Improvements:**

* [`InspectorCommand.php`](diffhunk://#diff-9cd21de5b57cbd925470652e05a6a2cce64cfd11981d4abf7492400d447ebf16R8): Replaces direct ObjectManager usage for `ScopeConfigInterface` with constructor injection, and updates corresponding usage in the `isInspectorEnabled()` method. [[1]](diffhunk://#diff-9cd21de5b57cbd925470652e05a6a2cce64cfd11981d4abf7492400d447ebf16R8) [[2]](diffhunk://#diff-9cd21de5b57cbd925470652e05a6a2cce64cfd11981d4abf7492400d447ebf16R29) [[3]](diffhunk://#diff-9cd21de5b57cbd925470652e05a6a2cce64cfd11981d4abf7492400d447ebf16L203-R205)
* [`CheckCommand.php`](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9R9-R12): Injects `ResourceConnection` and `ClientFactory` via the constructor, removing ObjectManager calls in methods that require database and HTTP client access. Updates affected methods to use the injected dependencies. [[1]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9R9-R12) [[2]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9R32-R33) [[3]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9L184-R188) [[4]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9L587-R589)

**Input Validation and Error Handling:**

* [`BuildCommand.php`](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450R265-R269): Adds a check for a missing theme path and reports an error if the path is not found, preventing further execution.
* [`WatchCommand.php`](diffhunk://#diff-2e3fca0327c8667057939ae7ad75a765c6230ea0c7e70892f6b3f3f7fd945602R117-R121): Adds error reporting if no suitable builder is found for the given theme, returning a failure status.

**Sanitization Enhancements:**

* `BuildCommand.php` & `CleanCommand.php`: Improves the `sanitizeTermValue` and `sanitizeAlphanumericValue` methods to handle cases where `preg_replace` returns `null`, ensuring robust input validation. [[1]](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450R455-R457) [[2]](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450R476-R478) [[3]](diffhunk://#diff-8d49db830f9f46fc087d43d1e114262c48083b21ec0e34402e87b0dae9006a3fR602-R604) [[4]](diffhunk://#diff-8d49db830f9f46fc087d43d1e114262c48083b21ec0e34402e87b0dae9006a3fR623-R625)

**Static Analysis Configuration:**

* [`phpstan.neon`](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766L2-R2): Increases the PHPStan analysis level from 7 to 8, enforcing stricter static analysis.