### PR TITLE
fix: correct spacing and formatting in multiple files

### DIFF
--- a/src/Console/Command/System/CheckCommand.php
+++ b/src/Console/Command/System/CheckCommand.php
@@ -551,7 +551,9 @@ class CheckCommand extends AbstractCommand
         }
 
         return 'Search Engine Available';
-    }    /**
+    }
+    
+    /**
      * Test Elasticsearch connection and return version info
      *
      * @param string $url
@@ -653,7 +655,9 @@ class CheckCommand extends AbstractCommand
         $usedPercent = round(($usedGB / $totalGB) * 100, 2);
 
         return "$usedGB GB / $totalGB GB ($usedPercent%)";
-    }    /**
+    }
+
+    /**
      * Safely get environment variable value
      *
      * @param string $name Environment variable name

--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -181,7 +181,7 @@ class BuildCommand extends AbstractCommand
                 $spinner = new Spinner(sprintf("Building %s (%d of %d) ...", $themeNameCyan, $currentTheme, $totalThemes));
                 $success = false;
 
-                $spinner->spin(function() use ($validatedTheme, $io, $output, $isVerbose, &$successList, &$success) {
+                $spinner->spin(function () use ($validatedTheme, $io, $output, $isVerbose, &$successList, &$success) {
                     $success = $this->buildValidatedTheme($validatedTheme, $io, $output, $isVerbose, $successList);
                     return true;
                 });
@@ -423,7 +423,7 @@ class BuildCommand extends AbstractCommand
      */
     private function sanitizeEnvironmentValue(string $name, string $value): ?string
     {
-        return match($name) {
+        return match ($name) {
             'COLUMNS', 'LINES' => $this->sanitizeNumericValue($value),
             'TERM' => $this->sanitizeTermValue($value),
             'CI', 'GITHUB_ACTIONS', 'GITLAB_CI' => $this->sanitizeBooleanValue($value),
@@ -497,7 +497,7 @@ class BuildCommand extends AbstractCommand
     private function setEnvVar(string $name, string $value): void
     {
         // Validate input parameters
-        if (empty($name) ) {
+        if (empty($name)) {
             return;
         }
 
@@ -535,7 +535,9 @@ class BuildCommand extends AbstractCommand
     {
         // Reset our secure storage
         $this->secureEnvStorage = [];
-    }    /**
+    }
+
+    /**
      * Check if the current environment supports interactive terminal input
      *
      * @param OutputInterface $output

--- a/src/Console/Command/Theme/CleanCommand.php
+++ b/src/Console/Command/Theme/CleanCommand.php
@@ -575,7 +575,7 @@ class CleanCommand extends AbstractCommand
      */
     private function sanitizeEnvironmentValue(string $name, string $value): ?string
     {
-        return match($name) {
+        return match ($name) {
             'COLUMNS', 'LINES' => $this->sanitizeNumericValue($value),
             'TERM' => $this->sanitizeTermValue($value),
             'CI', 'GITHUB_ACTIONS', 'GITLAB_CI' => $this->sanitizeBooleanValue($value),
@@ -643,7 +643,7 @@ class CleanCommand extends AbstractCommand
      */
     private function setEnvVar(string $name, string $value): void
     {
-        if (empty($name) ) {
+        if (empty($name)) {
             return;
         }
 

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -16,7 +16,8 @@ class NodePackageManager
     public function __construct(
         private readonly Shell $shell,
         private readonly FileDriver $fileDriver
-    ) {}
+    ) {
+    }
 
     /**
      * Install node modules in the specified directory

--- a/src/view/frontend/templates/inspector.phtml
+++ b/src/view/frontend/templates/inspector.phtml
@@ -11,7 +11,7 @@
  */
 ?>
 <!-- MageForge Inspector Assets -->
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getCssUrl()) ?>" />
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getCssUrl()) ?>" />
 
 <!-- Alpine.js Bootstrap (load only if not already present) -->
 <script>
@@ -41,7 +41,7 @@
 })();
 </script>
 
-<script defer src="<?= $block->escapeUrl($block->getJsUrl()) ?>"></script>
+<script defer src="<?= $escaper->escapeUrl($block->getJsUrl()) ?>"></script>
 
 <!-- Inspector Component Wrapper -->
 <div class="mageforge-inspector" x-data="mageforgeInspector"></div>


### PR DESCRIPTION
This pull request consists of minor code quality and consistency improvements across several files, as well as a small fix to template escaping. The most significant change is the consistent use of the `$escaper` object for URL escaping in the frontend template to improve security and maintain best practices.

**Frontend template security and consistency:**
* Updated `src/view/frontend/templates/inspector.phtml` to use the `$escaper` object instead of `$block` for URL escaping in both the stylesheet and script tags, ensuring proper output sanitization. [[1]](diffhunk://#diff-c7d7f77732cda4e2b1324047ccc74cbf1f7a7c66a5eb62412440183f652e9882L14-R14) [[2]](diffhunk://#diff-c7d7f77732cda4e2b1324047ccc74cbf1f7a7c66a5eb62412440183f652e9882L44-R44)

**Code formatting and style improvements:**
* Fixed formatting in several PHP files by adding proper line breaks before docblocks and after method closures in `CheckCommand.php`, `BuildCommand.php`, and the `NodePackageManager` constructor for better readability and adherence to coding standards. [[1]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9L554-R556) [[2]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9L656-R660) [[3]](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450L538-R540) [[4]](diffhunk://#diff-3d5549134445295138d538803ac95594fff629d8975703ed18ce2e9a8356a0ebL19-R20)