### PR TITLE
fix: return theme parts as array in parseThemeName

### DIFF
--- a/src/Service/ThemeCleaner.php
+++ b/src/Service/ThemeCleaner.php
@@ -317,6 +317,6 @@ class ThemeCleaner
             return null;
         }
 
-        return $themeParts;
+        return [$themeParts[0], $themeParts[1]];
     }
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the `parseThemeName` method in `ThemeCleaner.php` to ensure it always returns only the first two elements of the parsed theme name, rather than the entire array.