### PR TITLE
feat(actions): replace elasticsearch with opensearch

### DIFF
--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-elasticsearch:
-    name: Magento ${{ matrix.magento-version }} with PHP ${{ matrix.php-version }} Test
+  test-opensearch-247:
+    name: Magento ${{ matrix.magento-version }} with PHP ${{ matrix.php-version }} (OpenSearch) Test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -17,10 +17,10 @@ jobs:
         include:
           - magento-version: "2.4.7"
             php-version: "8.3"
-            search-engine-name: "elasticsearch7"
+            search-engine-name: "opensearch"
           - magento-version: "2.4.7-p8"
             php-version: "8.3"
-            search-engine-name: "elasticsearch7"
+            search-engine-name: "opensearch"
 
     services:
       mysql:
@@ -32,14 +32,14 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      elasticsearch:
-        image: elasticsearch:7.17.0
+      opensearch:
+        image: opensearchproject/opensearch:2.11.0
         ports:
           - 9200:9200
         env:
           discovery.type: single-node
-          ES_JAVA_OPTS: -Xms512m -Xmx512m -Djava.io.tmpdir=/tmp
-          JVM_OPTS: -XX:-UseContainerSupport
+          plugins.security.disabled: true
+          OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
         options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
     steps:
@@ -96,9 +96,9 @@ jobs:
             --use-rewrites=1 \
             --backend-frontname=admin \
             --search-engine=${{ matrix.search-engine-name }} \
-            --elasticsearch-host=localhost \
-            --elasticsearch-port=9200 \
-            --elasticsearch-index-prefix=magento \
+            --opensearch-host=localhost \
+            --opensearch-port=9200 \
+            --opensearch-index-prefix=magento \
             --cleanup-database
 
       - name: Install MageForge Module from current commit


### PR DESCRIPTION
This pull request updates the Magento compatibility GitHub Actions workflow to use OpenSearch instead of Elasticsearch for Magento 2.4.7 test jobs. The changes ensure that the workflow is compatible with the latest Magento requirements and reflect the migration from Elasticsearch to OpenSearch.

**Migration to OpenSearch for Magento 2.4.7 Compatibility Testing:**

- **Workflow Job and Matrix Updates:**
  * Renamed the test job from `test-elasticsearch` to `test-opensearch-247` and updated the matrix to use `opensearch` as the search engine name for Magento 2.4.7 and 2.4.7-p8 test runs.

- **Service Container Changes:**
  * Replaced the `elasticsearch` service with an `opensearch` service using the `opensearchproject/opensearch:2.11.0` image, updated environment variables, and disabled security plugins for easier local testing.

- **Magento Install Step Adjustments:**
  * Updated the Magento installation command to use OpenSearch-specific flags (`--opensearch-host`, `--opensearch-port`, `--opensearch-index-prefix`) instead of Elasticsearch flags.