### PR TITLE
feat: improve npm failure diagnostics with detailed error messages

### DIFF
--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -308,13 +308,23 @@ class NodePackageManager
             return false; // Directory doesn't exist yet, so no permission issues
         }
 
+        $testFile = $nodeModulesPath . '/.write-test-' . time();
+
         try {
             // Try to write a test file
-            $testFile = $nodeModulesPath . '/.write-test-' . uniqid('', true);
             $this->fileDriver->filePutContents($testFile, 'test');
             $this->fileDriver->deleteFile($testFile);
             return false;
         } catch (\Exception $e) {
+            if (is_file($testFile) && !@unlink($testFile)) {
+                error_log(
+                    sprintf(
+                        '[MageForge] Failed to clean up test file "%s": %s',
+                        $testFile,
+                        $e->getMessage()
+                    )
+                );
+            }
             return true;
         }
     }


### PR DESCRIPTION
This pull request enhances error handling for npm installation failures in the `NodePackageManager` service. The main improvement is the addition of a diagnostic method that analyzes common causes of `npm install` errors and provides targeted troubleshooting advice to the user. This should make it easier to identify and resolve issues during node module installation.

Improvements to npm error diagnosis and reporting:

* Added a new private method `diagnoseAndReportNpmFailure` to `NodePackageManager.php` that checks for common problems (such as missing npm/node, invalid `package.json`, corrupted `package-lock.json`, permission issues, insufficient disk space, npm cache corruption, and network errors) and displays specific error messages and suggested fixes to the user.
* Updated the error handling in `installNodeModules` to call `diagnoseAndReportNpmFailure` instead of displaying a generic error message, providing more actionable feedback.

New helper methods for diagnostics:

* Introduced helper methods: `isCommandAvailable`, `isPackageJsonValid`, `isPackageLockValid`, `hasPermissionIssues`, and `hasSufficientDiskSpace` to support detailed checks in the diagnostic process.

Thanks [therouv](https://github.com/therouv) for reporting.