### PR TITLE
fix: ensure theme codes are indexed correctly in commands

### DIFF
--- a/src/Console/Command/Theme/BuildCommand.php
+++ b/src/Console/Command/Theme/BuildCommand.php
@@ -70,7 +70,7 @@ class BuildCommand extends AbstractCommand
 
         if (empty($themeCodes)) {
             $themes = $this->themeList->getAllThemes();
-            $options = array_map(fn($theme) => $theme->getCode(), $themes);
+            $options = array_values(array_map(fn($theme) => $theme->getCode(), $themes));
 
             // Check if we're in an interactive terminal environment
             if (!$this->isInteractiveTerminal($output)) {

--- a/src/Console/Command/Theme/CleanCommand.php
+++ b/src/Console/Command/Theme/CleanCommand.php
@@ -141,7 +141,7 @@ class CleanCommand extends AbstractCommand
     private function selectThemesInteractively(OutputInterface $output): ?array
     {
         $themes = $this->themeList->getAllThemes();
-        $options = array_map(fn($theme) => $theme->getCode(), $themes);
+        $options = array_values(array_map(fn($theme) => $theme->getCode(), $themes));
 
         if (!$this->isInteractiveTerminal($output)) {
             $this->displayAvailableThemes($themes);

--- a/src/Console/Command/Theme/TokensCommand.php
+++ b/src/Console/Command/Theme/TokensCommand.php
@@ -106,7 +106,7 @@ class TokensCommand extends AbstractCommand
         }
 
         $themes = $this->themeList->getAllThemes();
-        $options = array_map(fn($theme) => $theme->getCode(), $themes);
+        $options = array_values(array_map(fn($theme) => $theme->getCode(), $themes));
 
         $themeCodePrompt = new SearchPrompt(
             label: 'Select theme to generate tokens for',


### PR DESCRIPTION
This pull request makes a small but important adjustment to how theme codes are collected and indexed in several theme-related console commands. The change ensures that the arrays of theme codes always have sequential numeric indexes, which can prevent potential issues with array handling in downstream logic.

The main change is:

* Standardized the creation of the `$options` array in `BuildCommand.php`, `CleanCommand.php`, and `TokensCommand.php` by wrapping the `array_map` call with `array_values`, ensuring that theme code arrays use zero-based sequential indexes. [[1]](diffhunk://#diff-d0f36d4a86ecdbae77eb667550c7c10736df29654d43dcba0eeec2af50da1450L73-R73) [[2]](diffhunk://#diff-8d49db830f9f46fc087d43d1e114262c48083b21ec0e34402e87b0dae9006a3fL144-R144) [[3]](diffhunk://#diff-980df1ffccde1f84cea928ad3319be76a21992355f89b12c5fa9f056a0d547ecL109-R109)