### PR TITLE
feat: update PHP and Magento framework requirements in composer.json #155

### DIFF
--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -24,6 +24,9 @@ jobs:
           - magento-version: "2.4.9-beta1"
             php-version: "8.4"
             search-engine-name: "opensearch"
+          - magento-version: "2.4.9-beta1"
+            php-version: "8.5"
+            search-engine-name: "opensearch"
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     }
   },
   "require": {
-    "php": ">=8.3",
-    "magento/framework": ">=103.0.7",
+    "php": "^8.3 || ^8.4 || ^8.5",
+    "magento/framework": "^103.0.7",
     "laravel/prompts": "^0.3.5"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
     }
   },
   "require": {
+    "php": ">=8.3",
+    "magento/framework": ">=103.0.7",
     "laravel/prompts": "^0.3.5"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "openforgeproject/mageforge",
-  "description": "Magento 2 module for frontend wizardry~",
+  "description": "Magento 2 module for frontend workflow automation",
   "version": "0.15.1",
   "license": "GPL-3.0",
   "type": "magento2-module",
@@ -13,8 +13,8 @@
     }
   },
   "require": {
-    "php": "^8.3 || ^8.4 || ^8.5",
-    "magento/framework": "^103.0.7",
+    "php": "~8.3.0||~8.4.0||~8.5.0",
+    "magento/framework": "103.0.*",
     "laravel/prompts": "^0.3.5"
   }
 }


### PR DESCRIPTION
This pull request for Issue #155 adds support for PHP 8.5 and updates compatibility requirements for both PHP and Magento. The main changes ensure the project can run on newer PHP versions and Magento framework releases.

Compatibility updates:

* Updated the `composer.json` `require` section to support PHP versions 8.3, 8.4, and 8.5, and require `magento/framework` version `^103.0.7`.
* Added a new job to the GitHub Actions workflow (`.github/workflows/magento-compatibility.yml`) to test against PHP 8.5 with Magento 2.4.9-beta1 and OpenSearch.