### PR TITLE
fix: adjust initial badge position and add scroll handler for connector

### DIFF
--- a/src/view/frontend/web/js/inspector.js
+++ b/src/view/frontend/web/js/inspector.js
@@ -52,8 +52,10 @@ function _registerMageforgeInspector() {
         initialBadgeX: 0,
         initialBadgeY: 0,
         connectorSvg: null,
+        dragStartHandler: null,
         dragHandler: null,
         dragEndHandler: null,
+        connectorScrollHandler: null,
 
         // Performance Thresholds
         PERF_RENDER_TIME_GOOD: 50, // ms

--- a/src/view/frontend/web/js/inspector/draggable.js
+++ b/src/view/frontend/web/js/inspector/draggable.js
@@ -47,8 +47,8 @@ export const draggableMethods = {
         this.dragStartY = e.clientY;
 
         const rect = this.infoBadge.getBoundingClientRect();
-        this.initialBadgeX = rect.left;
-        this.initialBadgeY = rect.top;
+        this.initialBadgeX = rect.left + window.scrollX;
+        this.initialBadgeY = rect.top + window.scrollY;
 
         // Remove static arrow
         const arrow = this.infoBadge.querySelector('.mageforge-inspector-arrow');
@@ -113,6 +113,11 @@ export const draggableMethods = {
 
         document.body.appendChild(svg);
         this.connectorSvg = svg;
+
+        // Update line on scroll (SVG is fixed, coordinates are viewport-relative)
+        this.connectorScrollHandler = () => this.updateConnector();
+        window.addEventListener('scroll', this.connectorScrollHandler, { passive: true });
+
         this.updateConnector();
     },
 
@@ -120,6 +125,10 @@ export const draggableMethods = {
      * Remove connector
      */
     removeConnector() {
+        if (this.connectorScrollHandler) {
+            window.removeEventListener('scroll', this.connectorScrollHandler);
+            this.connectorScrollHandler = null;
+        }
         if (this.connectorSvg) {
             this.connectorSvg.remove();
             this.connectorSvg = null;


### PR DESCRIPTION
This pull request improves the drag-and-drop functionality of the Mageforge Inspector overlay, especially in scenarios where the page is scrolled. The most important changes are grouped below by theme.

**Drag-and-drop accuracy and behavior:**

* The initial position of the draggable badge (`initialBadgeX` and `initialBadgeY`) now accounts for the page scroll offset, ensuring the badge moves accurately even when the page is scrolled.

**Connector line rendering and scroll handling:**

* A new `connectorScrollHandler` is introduced to update the connector line position when the window is scrolled, keeping the connector accurately attached to the badge. The handler is added when the connector is created and removed when the connector is destroyed to prevent memory leaks. [[1]](diffhunk://#diff-82f418be83778fb61396948cac3aeddfdd272f1931c3ab2526cba22915aa4603R55-R58) [[2]](diffhunk://#diff-cbfc90a327127d5cb74acbd2e79cebd204f7722544e7058aefa3466d9347c428R116-R131)