### PR TITLE
refactor: remove feature views and new badge logic from inspector

### DIFF
--- a/src/view/frontend/web/css/inspector.css
+++ b/src/view/frontend/web/css/inspector.css
@@ -461,19 +461,6 @@
     border-bottom-color: var(--mageforge-color-blue);
 }
 
-.mageforge-badge-new {
-    background: linear-gradient(135deg, var(--mageforge-color-amber) 0%, var(--mageforge-color-amber) 100%);
-    color: white;
-    font-size: 8px;
-    padding: 1px 4px;
-    border-radius: 4px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    animation: mageforge-pulse 2s infinite;
-}
-
 /* ============================================================================
    Info Sections & Data Display
    ========================================================================== */

--- a/src/view/frontend/web/js/inspector.js
+++ b/src/view/frontend/web/js/inspector.js
@@ -75,13 +75,6 @@ function _registerMageforgeInspector() {
         pageTimings: null,
         performanceObservers: [],
 
-        // Feature Discovery
-        MAX_NEW_BADGE_VIEWS: 5,
-        featureViews: {
-            'performance': 0,
-            'core-web-vitals': 0
-        },
-
         // ====================================================================
         // Lifecycle
         // ====================================================================
@@ -101,7 +94,6 @@ function _registerMageforgeInspector() {
             this.createFloatingButton();
             this.initWebVitalsTracking();
             this.cachePageTimings();
-            this.loadFeatureViews();
 
             // Dispatch init event for Hyvä integration
             this.$dispatch('mageforge:inspector:init');
@@ -138,39 +130,6 @@ function _registerMageforgeInspector() {
             if (this.connectorSvg) {
                 this.connectorSvg.remove();
                 this.connectorSvg = null;
-            }
-        },
-
-        // ====================================================================
-        // Feature Views
-        // ====================================================================
-
-        loadFeatureViews() {
-            try {
-                const stored = localStorage.getItem('mageforge_feature_views');
-                if (stored) {
-                    this.featureViews = { ...this.featureViews, ...JSON.parse(stored) };
-                }
-            } catch (e) {
-                console.warn('MageForge: Failed to load feature views', e);
-            }
-        },
-
-        incrementFeatureViews() {
-            let changed = false;
-            ['performance', 'core-web-vitals'].forEach(feature => {
-                if (this.featureViews[feature] < this.MAX_NEW_BADGE_VIEWS) {
-                    this.featureViews[feature]++;
-                    changed = true;
-                }
-            });
-
-            if (changed) {
-                try {
-                    localStorage.setItem('mageforge_feature_views', JSON.stringify(this.featureViews));
-                } catch (e) {
-                    // Ignore storage errors
-                }
             }
         },
 

--- a/src/view/frontend/web/js/inspector/picker.js
+++ b/src/view/frontend/web/js/inspector/picker.js
@@ -136,7 +136,6 @@ export const pickerMethods = {
                 this.showHighlight(element);
                 this.updatePanelData(element);
                 this.showInfoBadge(element);
-                this.incrementFeatureViews();
             }, this.hoverDelay);
         } else if (!element && this.hoveredElement) {
             // Only hide highlight when leaving element, keep badge visible

--- a/src/view/frontend/web/js/inspector/tabs.js
+++ b/src/view/frontend/web/js/inspector/tabs.js
@@ -37,15 +37,6 @@ export const tabsMethods = {
             textSpan.textContent = tab.label;
             button.appendChild(textSpan);
 
-            // Show "New" badge for Performance and Core Web Vitals if seen < 5 times
-            if (['performance', 'core-web-vitals'].includes(tab.id) &&
-                (this.featureViews[tab.id] || 0) < this.MAX_NEW_BADGE_VIEWS) {
-                const badge = document.createElement('span');
-                badge.className = 'mageforge-badge-new';
-                badge.textContent = 'NEW';
-                button.appendChild(badge);
-            }
-
             button.onclick = (e) => {
                 e.preventDefault();
                 e.stopPropagation();


### PR DESCRIPTION
This pull request removes the "NEW" badge feature from the MageForge Inspector UI, including all related logic for tracking and displaying the badge for new features. The main changes are grouped as follows:

**Removal of "NEW" Badge UI and Logic:**

* Deleted the `.mageforge-badge-new` CSS class from `inspector.css`, removing the visual styling for the "NEW" badge.
* Removed the logic for displaying the "NEW" badge on the Performance and Core Web Vitals tabs from `tabs.js`.
* Eliminated all feature view tracking state and constants (such as `MAX_NEW_BADGE_VIEWS` and `featureViews`) from `inspector.js`.
* Removed the methods for loading and incrementing feature views from local storage (`loadFeatureViews` and `incrementFeatureViews`) in `inspector.js`.
* Deleted all calls to feature view tracking methods, including removing the call to `loadFeatureViews()` during initialization and `incrementFeatureViews()` from picker logic. [[1]](diffhunk://#diff-82f418be83778fb61396948cac3aeddfdd272f1931c3ab2526cba22915aa4603L104) [[2]](diffhunk://#diff-9afe866f46706f107da986c074ed519c69813bbdd70de84677aeae2be81de686L139)

These changes simplify the codebase by removing an unused or obsolete feature.