### PR TITLE
fix: remove INP metric tracking from performance and vitals modules

### DIFF
--- a/src/view/frontend/web/js/inspector.js
+++ b/src/view/frontend/web/js/inspector.js
@@ -68,7 +68,6 @@ function _registerMageforgeInspector() {
         webVitals: {
             lcp: null,
             cls: [],
-            inp: null,
             fcp: null,
             elementTimings: [] // Element Timing API results
         },

--- a/src/view/frontend/web/js/inspector/performance.js
+++ b/src/view/frontend/web/js/inspector/performance.js
@@ -107,7 +107,6 @@ export const performanceMethods = {
         if (this.renderRenderTimeMetric(container, element)) hasMetrics = true;
         if (this.renderLCPMetric(container, element)) hasMetrics = true;
         if (this.renderCLSMetric(container, element)) hasMetrics = true;
-        if (this.renderINPMetric(container, element)) hasMetrics = true;
         if (this.renderElementTimingMetric(container, element)) hasMetrics = true;
         if (this.renderImageOptimizationMetric(container, element)) hasMetrics = true;
         if (this.renderResourceMetric(container, element)) hasMetrics = true;
@@ -167,19 +166,6 @@ export const performanceMethods = {
             const stabilityColor = stabilityScore > 0.75 ? '#34d399' : (stabilityScore > 0.5 ? '#f59e0b' : '#ef4444');
             container.appendChild(
                 this.createInfoSection('Layout Stability Score', stabilityScore, stabilityColor)
-            );
-            return true;
-        }
-        return false;
-    },
-
-    renderINPMetric(container, element) {
-        const isInteractive = this.checkIfInteractive(element, element.tagName.toLowerCase(), element.getAttribute('role'));
-        if (isInteractive && this.webVitals.inp) {
-            const inpValue = this.webVitals.inp.duration.toFixed(0);
-            const inpColor = inpValue < 200 ? '#34d399' : (inpValue < 500 ? '#f59e0b' : '#ef4444');
-            container.appendChild(
-                this.createInfoSection('INP (Interaction)', `${inpValue} ms`, inpColor)
             );
             return true;
         }

--- a/src/view/frontend/web/js/inspector/vitals.js
+++ b/src/view/frontend/web/js/inspector/vitals.js
@@ -42,21 +42,6 @@ export const vitalsMethods = {
             clsObserver.observe({ type: 'layout-shift', buffered: true });
             this.performanceObservers.push(clsObserver);
 
-            // Interaction to Next Paint (INP) - via first-input as fallback
-            const inpObserver = new PerformanceObserver((list) => {
-                const entries = list.getEntries();
-                if (entries.length > 0) {
-                    const firstEntry = entries[0];
-                    this.webVitals.inp = {
-                        delay: firstEntry.processingStart - firstEntry.startTime,
-                        duration: firstEntry.duration,
-                        time: firstEntry.startTime
-                    };
-                }
-            });
-            inpObserver.observe({ type: 'first-input', buffered: true });
-            this.performanceObservers.push(inpObserver);
-
             // First Contentful Paint (FCP)
             const paintObserver = new PerformanceObserver((list) => {
                 for (const entry of list.getEntries()) {


### PR DESCRIPTION
This pull request removes support for the INP (Interaction to Next Paint) performance metric from the inspector's frontend code. The changes eliminate INP data collection, storage, and display, simplifying the performance metrics logic.

**Performance Metrics Removal**

* Removed the INP metric from the `webVitals` data structure in `inspector.js`, so INP values are no longer tracked.
* Stopped collecting INP data by removing the `PerformanceObserver` for the `'first-input'` event in `vitals.js`.
* Removed the `renderINPMetric` function and its invocation from `performance.js`, so INP is no longer displayed in the UI. [[1]](diffhunk://#diff-3eaa2d2a6264de1c16d673dd7d33031d7fc250a3d6f7bfbebf3484fb31319566L110) [[2]](diffhunk://#diff-3eaa2d2a6264de1c16d673dd7d33031d7fc250a3d6f7bfbebf3484fb31319566L176-L188)