### PR TITLE
refactor: use WeakMap for block data storage in inspector

### DIFF
--- a/src/view/frontend/web/js/inspector.js
+++ b/src/view/frontend/web/js/inspector.js
@@ -14,6 +14,7 @@ import { accessibilityMethods } from './inspector/accessibility.js';
 import { performanceMethods } from './inspector/performance.js';
 import { vitalsMethods } from './inspector/vitals.js';
 import { draggableMethods } from './inspector/draggable.js';
+import { blockDataMap } from './inspector/blockData.js';
 
 // Extracted into a named function so it can be called either from the
 // alpine:init event (normal case) or immediately when Alpine has already
@@ -139,7 +140,7 @@ function _registerMageforgeInspector() {
         // ====================================================================
 
         updatePanelData(element) {
-            const data = element._mageforgeBlockData;
+            const data = blockDataMap.get(element);
 
             if (!data) {
                 this.panelData.template = 'N/A';

--- a/src/view/frontend/web/js/inspector/blockData.js
+++ b/src/view/frontend/web/js/inspector/blockData.js
@@ -1,0 +1,9 @@
+/**
+ * MageForge Inspector - Block Data Storage
+ *
+ * Shared WeakMap for associating block metadata with DOM elements.
+ * Using WeakMap avoids polluting the HTMLElement namespace and allows
+ * garbage collection when elements are removed from the DOM.
+ */
+
+export const blockDataMap = new WeakMap();

--- a/src/view/frontend/web/js/inspector/picker.js
+++ b/src/view/frontend/web/js/inspector/picker.js
@@ -2,6 +2,8 @@
  * MageForge Inspector - Keyboard Shortcuts, Inspector Toggle & Element Picker
  */
 
+import { blockDataMap } from './blockData.js';
+
 export const pickerMethods = {
     /**
      * Setup keyboard shortcuts
@@ -226,8 +228,7 @@ export const pickerMethods = {
         // Check if this element is part of a MageForge block
         const block = this.findBlockForElement(target);
         if (block) {
-            // Attach block data to element for easy access
-            target._mageforgeBlockData = block.data;
+            blockDataMap.set(target, block.data);
             return target;
         }
 

--- a/src/view/frontend/web/js/inspector/ui.js
+++ b/src/view/frontend/web/js/inspector/ui.js
@@ -2,6 +2,8 @@
  * MageForge Inspector - UI Element Creation & Badge Positioning
  */
 
+import { blockDataMap } from './blockData.js';
+
 export const uiMethods = {
     /**
      * Create highlight overlay box
@@ -160,7 +162,7 @@ export const uiMethods = {
      * Build badge content with element metadata
      */
     buildBadgeContent(element) {
-        const data = element._mageforgeBlockData || {
+        const data = blockDataMap.get(element) || {
             template: '',
             block: '',
             module: '',


### PR DESCRIPTION
This pull request refactors how block metadata is associated with DOM elements in the MageForge Inspector. Instead of attaching data directly to elements as a custom property, it now uses a shared `WeakMap` (`blockDataMap`). This approach avoids polluting the DOM element namespace and allows for better memory management.

**Block metadata storage refactor:**

* Introduced a new `blockDataMap` (a `WeakMap`) in `inspector/blockData.js` to store block metadata associated with DOM elements, enabling automatic garbage collection and preventing namespace pollution.
* Updated all usages to retrieve block data from `blockDataMap` instead of the `_mageforgeBlockData` property in `inspector.js`, `picker.js`, and `ui.js`. [[1]](diffhunk://#diff-82f418be83778fb61396948cac3aeddfdd272f1931c3ab2526cba22915aa4603L142-R143) [[2]](diffhunk://#diff-9afe866f46706f107da986c074ed519c69813bbdd70de84677aeae2be81de686L229-R231) [[3]](diffhunk://#diff-558909ee39abe1ee6986f6846cf84a6a24b957394ec8f6f9b36e62ea87ba04ebL163-R165)
* Updated imports in relevant files to import `blockDataMap` from the new module. [[1]](diffhunk://#diff-82f418be83778fb61396948cac3aeddfdd272f1931c3ab2526cba22915aa4603R17) [[2]](diffhunk://#diff-9afe866f46706f107da986c074ed519c69813bbdd70de84677aeae2be81de686R5-R6) [[3]](diffhunk://#diff-558909ee39abe1ee6986f6846cf84a6a24b957394ec8f6f9b36e62ea87ba04ebR5-R6)