### PR TITLE
Fix/inspector in magewire templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ To disable the inspector:
 bin/magento mageforge:theme:inspector disable
 ```
 
+> **Note:** The Inspector is currently not compatible with **Magewire** components. Magewire blocks are automatically excluded from inspection to prevent rendering errors.
+
 
 
 ---

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -30,6 +30,7 @@ class InspectorHints implements TemplateEngineInterface
      * @param BlockCacheCollector $cacheCollector
      * @param File $fileDriver
      * @param string[] $excludedClassPrefixes Block class prefixes to skip inspector wrapping for
+     * @param string[] $excludedTemplatePaths Template path substrings to skip inspector wrapping for
      */
     public function __construct(
         private readonly TemplateEngineInterface $subject,
@@ -38,6 +39,7 @@ class InspectorHints implements TemplateEngineInterface
         private readonly BlockCacheCollector $cacheCollector,
         private readonly File $fileDriver,
         private readonly array $excludedClassPrefixes = [],
+        private readonly array $excludedTemplatePaths = [],
     ) {
         $this->magentoRoot = $this->resolveMagentoRoot();
     }
@@ -70,6 +72,24 @@ class InspectorHints implements TemplateEngineInterface
     {
         foreach ($this->excludedClassPrefixes as $prefix) {
             if (str_starts_with($blockClass, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a template path should be excluded from inspector wrapping
+     *
+     * @param string $templateFile
+     * @return bool
+     */
+    private function isExcludedTemplate(string $templateFile): bool
+    {
+        $normalized = str_replace('\\', '/', strtolower($templateFile));
+        foreach ($this->excludedTemplatePaths as $path) {
+            if (str_contains($normalized, strtolower($path))) {
                 return true;
             }
         }
@@ -113,6 +133,13 @@ class InspectorHints implements TemplateEngineInterface
 
         // Skip inspector wrapping for excluded block classes (e.g. Magewire components)
         if ($this->isExcluded(get_class($block))) {
+            return $result;
+        }
+
+        // Skip inspector wrapping for templates in excluded paths (e.g. /magewire/ directories).
+        // Magewire injects wire:id AFTER the template engine returns via regex on the root element.
+        // Wrapping the output in HTML comments before that element breaks the injection.
+        if ($this->isExcludedTemplate($templateFile)) {
             return $result;
         }
 

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -78,6 +78,20 @@ class InspectorHints implements TemplateEngineInterface
     }
 
     /**
+     * Check if rendered HTML contains wire attributes (Magewire/Livewire components)
+     *
+     * Wrapping these in HTML comments breaks wire:id injection which relies on
+     * finding the first root element via regex.
+     *
+     * @param string $html
+     * @return bool
+     */
+    private function containsWireAttributes(string $html): bool
+    {
+        return str_contains($html, 'wire:id=') || str_contains($html, 'wire:initial-data=');
+    }
+
+    /**
      * Insert inspector data attributes into the rendered block contents
      *
      * @param BlockInterface $block
@@ -99,6 +113,11 @@ class InspectorHints implements TemplateEngineInterface
 
         // Skip inspector wrapping for excluded block classes (e.g. Magewire components)
         if ($this->isExcluded(get_class($block))) {
+            return $result;
+        }
+
+        // Skip inspector wrapping if the rendered HTML contains wire attributes (Magewire/Livewire)
+        if ($this->containsWireAttributes($result)) {
             return $result;
         }
 

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -89,7 +89,7 @@ class InspectorHints implements TemplateEngineInterface
     {
         $normalized = str_replace('\\', '/', strtolower($templateFile));
         foreach ($this->excludedTemplatePaths as $path) {
-            if (str_contains($normalized, strtolower($path))) {
+            if (str_contains($normalized, str_replace('\\', '/', strtolower(trim($path))))) {
                 return true;
             }
         }

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -29,6 +29,7 @@ class InspectorHints implements TemplateEngineInterface
      * @param Random $random
      * @param BlockCacheCollector $cacheCollector
      * @param File $fileDriver
+     * @param string[] $excludedClassPrefixes Block class prefixes to skip inspector wrapping for
      */
     public function __construct(
         private readonly TemplateEngineInterface $subject,
@@ -36,6 +37,7 @@ class InspectorHints implements TemplateEngineInterface
         private readonly Random $random,
         private readonly BlockCacheCollector $cacheCollector,
         private readonly File $fileDriver,
+        private readonly array $excludedClassPrefixes = [],
     ) {
         $this->magentoRoot = $this->resolveMagentoRoot();
     }
@@ -59,6 +61,23 @@ class InspectorHints implements TemplateEngineInterface
     }
 
     /**
+     * Check if a block class should be excluded from inspector wrapping
+     *
+     * @param string $blockClass
+     * @return bool
+     */
+    private function isExcluded(string $blockClass): bool
+    {
+        foreach ($this->excludedClassPrefixes as $prefix) {
+            if (str_starts_with($blockClass, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Insert inspector data attributes into the rendered block contents
      *
      * @param BlockInterface $block
@@ -75,6 +94,11 @@ class InspectorHints implements TemplateEngineInterface
         $endTime = hrtime(true);
 
         if (!$this->showBlockHints) {
+            return $result;
+        }
+
+        // Skip inspector wrapping for excluded block classes (e.g. Magewire components)
+        if ($this->isExcluded(get_class($block))) {
             return $result;
         }
 

--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -116,7 +116,17 @@ class InspectorHints implements TemplateEngineInterface
             return $result;
         }
 
-        // Skip inspector wrapping if the rendered HTML contains wire attributes (Magewire/Livewire)
+        // Skip inspector wrapping for Magewire component blocks.
+        // Magewire sets a 'magewire' data key on the block before rendering and injects wire:id
+        // via regex AFTER the template engine returns. Wrapping the output in HTML comments
+        // shifts the offset used by insertAttributesIntoHtmlRoot(), causing broken components.
+        // Soft dependency: hasData() is a Magento DataObject method, not a Magewire class.
+        if (method_exists($block, 'hasData') && $block->hasData('magewire')) {
+            return $result;
+        }
+
+        // Skip inspector wrapping if the rendered HTML contains wire attributes (Magewire/Livewire).
+        // This catches container blocks whose children have already been rendered with wire attributes.
         if ($this->containsWireAttributes($result)) {
             return $result;
         }

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -12,6 +12,10 @@
       <type name="OpenForgeProject\MageForge\Model\TemplateEngine\Decorator\InspectorHints">
             <arguments>
                   <argument name="cacheCollector" xsi:type="object">OpenForgeProject\MageForge\Service\Inspector\Cache\BlockCacheCollector</argument>
+                  <!-- Block class prefixes excluded from inspector wrapping (e.g. Magewire injects wire:id after render) -->
+                  <argument name="excludedClassPrefixes" xsi:type="array">
+                        <item name="magewire" xsi:type="string">Magewirephp\Magewire\</item>
+                  </argument>
             </arguments>
       </type>
 

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -16,6 +16,10 @@
                   <argument name="excludedClassPrefixes" xsi:type="array">
                         <item name="magewire" xsi:type="string">Magewirephp\Magewire\</item>
                   </argument>
+                  <!-- Template path substrings excluded from inspector wrapping (case-insensitive) -->
+                  <argument name="excludedTemplatePaths" xsi:type="array">
+                        <item name="magewire" xsi:type="string">magewire/</item>
+                  </argument>
             </arguments>
       </type>
 


### PR DESCRIPTION
This pull request improves compatibility between the Inspector and Magewire components by introducing several exclusion mechanisms to prevent rendering errors. The changes ensure that blocks and templates related to Magewire are automatically skipped by the Inspector, avoiding issues with wire attribute injection.

### Inspector exclusion mechanisms for Magewire compatibility

* Added constructor parameters `excludedClassPrefixes` and `excludedTemplatePaths` to `InspectorHints` to allow specifying block class prefixes and template path substrings that should be excluded from Inspector wrapping.
* Implemented methods `isExcluded`, `isExcludedTemplate`, and `containsWireAttributes` in `InspectorHints` to check if a block class, template path, or rendered HTML should be excluded from Inspector wrapping.
* Updated the `render` method in `InspectorHints` to skip Inspector wrapping for:
  * Excluded block classes and template paths,
  * Blocks with Magewire data,
  * Rendered HTML containing wire attributes (`wire:id`, `wire:initial-data`).
* Registered `Magewirephp\MagewireThis pull request improves compatibility between the Inspector and Magewire components by introducing several exclusion mechanisms to prevent rendering errors. The changes ensure that blocks and templates related to Magewire are automatically skipped by the Inspector, avoiding issues with wire attribute injection.

### Inspector exclusion mechanisms for Magewire compatibility

* Added constructor parameters `excludedClassPrefixes` and `excludedTemplatePaths` to `InspectorHints` to allow specifying block class prefixes and template path substrings that should be excluded from Inspector wrapping.
* Implemented methods `isExcluded`, `isExcludedTemplate`, and `containsWireAttributes` in `InspectorHints` to check if a block class, template path, or rendered HTML should be excluded from Inspector wrapping.
* Updated the `render` method in `InspectorHints` to skip Inspector wrapping for:
  * Excluded block classes and template paths,
  * Blocks with Magewire data,
  * Rendered HTML containing wire attributes (`wire:id`, `wire:initial-data`).
 as an excluded block class prefix and `magewire/` as an excluded template path in the DI configuration (`di.xml`).

### Documentation

* Added a note to the `README.md` explaining that the Inspector is not compatible with Magewire components and that Magewire blocks are automatically excluded from inspection.