### PR TITLE
fix: Remove the "cacheable" attribute from the inspector block, as this affects other page elements when Magento caching is enabled locally

### DIFF
--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -5,8 +5,7 @@
             <referenceContainer name="before.body.end">
                   <block class="OpenForgeProject\MageForge\Block\Inspector"
                          name="mageforge.inspector"
-                         template="OpenForgeProject_MageForge::inspector.phtml"
-                         cacheable="false" />
+                         template="OpenForgeProject_MageForge::inspector.phtml" />
             </referenceContainer>
       </body>
 </page>


### PR DESCRIPTION
This pull request makes a minor update to the `default.xml` layout file, specifically for the `mageforge.inspector` block. The change removes the `cacheable="false"` attribute, which may affect how the block is cached by Magento.

- Removed the `cacheable="false"` attribute from the `mageforge.inspector` block in `default.xml`, potentially allowing the block to be cached.