### PR TITLE
fix: refine theme path matching and enhance theme suggestion logic

### DIFF
--- a/src/Block/Inspector.php
+++ b/src/Block/Inspector.php
@@ -20,7 +20,14 @@ class Inspector extends Template
     private const XML_PATH_INSPECTOR_ENABLED = 'dev/mageforge_inspector/enabled';
     private const XML_PATH_SHOW_BUTTON_LABELS = 'mageforge/inspector/show_button_labels';
 
-    /** @phpstan-param array<string, mixed> $data */
+    /**
+     * @param Context $context
+     * @param State $state
+     * @param ScopeConfigInterface $scopeConfig
+     * @param DevHelper $devHelper
+     * @param array $data
+     * @phpstan-param array<string, mixed> $data
+     */
     public function __construct(
         Context $context,
         private readonly State $state,

--- a/src/Model/ThemePath.php
+++ b/src/Model/ThemePath.php
@@ -27,7 +27,7 @@ class ThemePath
     {
         $registeredThemes = $this->componentRegistrar->getPaths(ComponentRegistrar::THEME);
         foreach ($registeredThemes as $code => $path) {
-            if (str_contains($code, $themeCode)) {
+            if ($code === 'frontend/' . $themeCode || $code === 'adminhtml/' . $themeCode) {
                 return $path;
             }
         }

--- a/src/Model/ThemePath.php
+++ b/src/Model/ThemePath.php
@@ -26,12 +26,9 @@ class ThemePath
     public function getPath(string $themeCode): ?string
     {
         $registeredThemes = $this->componentRegistrar->getPaths(ComponentRegistrar::THEME);
-        foreach ($registeredThemes as $code => $path) {
-            if ($code === 'frontend/' . $themeCode || $code === 'adminhtml/' . $themeCode) {
-                return $path;
-            }
-        }
 
-        return null;
+        return $registeredThemes['frontend/' . $themeCode]
+            ?? $registeredThemes['adminhtml/' . $themeCode]
+            ?? null;
     }
 }

--- a/src/Service/ThemeSuggester.php
+++ b/src/Service/ThemeSuggester.php
@@ -18,11 +18,6 @@ class ThemeSuggester
      */
     private const MAX_SUGGESTIONS = 3;
 
-    /**
-     * Constructor
-     *
-     * @param ThemeList $themeList
-     */
     public function __construct(
         private readonly ThemeList $themeList,
     ) {
@@ -41,13 +36,17 @@ class ThemeSuggester
      */
     public function findSimilarThemes(string $invalidTheme): array
     {
+        if ($invalidTheme === '') {
+            return [];
+        }
+
         $themes = $this->themeList->getAllThemes();
         $threshold = (int) (strlen($invalidTheme) / 3);
         $suggestions = [];
 
         foreach ($themes as $theme) {
             $themeCode = $theme->getCode();
-            $distance = levenshtein($invalidTheme, $themeCode);
+            $distance = levenshtein(strtolower($invalidTheme), strtolower($themeCode));
 
             // Accept if: distance ≤ 1/3 of input length OR substring match (case-insensitive)
             if ($distance <= $threshold || str_contains(strtolower($themeCode), strtolower($invalidTheme))) {
@@ -55,10 +54,8 @@ class ThemeSuggester
             }
         }
 
-        // Sort by distance (best matches first)
         asort($suggestions);
 
-        // Return max 3 suggestions
         return array_slice(array_keys($suggestions), 0, self::MAX_SUGGESTIONS);
     }
 }

--- a/src/Service/ThemeSuggester.php
+++ b/src/Service/ThemeSuggester.php
@@ -18,6 +18,9 @@ class ThemeSuggester
      */
     private const MAX_SUGGESTIONS = 3;
 
+    /**
+     * @param ThemeList $themeList
+     */
     public function __construct(
         private readonly ThemeList $themeList,
     ) {


### PR DESCRIPTION
This pull request improves the accuracy and robustness of theme code matching and theme suggestions. The main changes include stricter matching logic in `ThemePath`, better handling of empty input, and more consistent, case-insensitive comparison in the theme suggestion logic.

**Theme path resolution improvements:**

* The `getPath` method in `ThemePath.php` now only returns a path if the theme code matches exactly with either `'frontend/' . $themeCode` or `'adminhtml/' . $themeCode`, instead of using a substring match. This prevents accidental partial matches and ensures more precise theme resolution.

**Theme suggestion robustness and accuracy:**

* The `findSimilarThemes` method in `ThemeSuggester.php` now immediately returns an empty array if the input theme name is empty, preventing unnecessary processing and possible errors.
* Theme code comparisons in `findSimilarThemes` are now performed in a case-insensitive manner for both Levenshtein distance and substring checks, improving the quality and user-friendliness of suggestions.

**Code cleanup:**

* Removed redundant constructor docblock comments in `ThemeSuggester.php` for improved code clarity.