### PR TITLE
security: pin all GitHub Actions to commit SHAs (GHSA-f9f8-rm49-7jv2)

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -23,7 +23,12 @@ jobs:
           MYSQL_DATABASE: magento
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pmagento --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+          --health-start-period=30s
 
       opensearch:
         image: opensearchproject/opensearch:2.11.0

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -42,7 +42,7 @@ jobs:
           path: mageforge
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f
         with:
           php-version: "8.4"
           extensions: mbstring, intl, gd, xml, soap, zip, bcmath, pdo_mysql, curl, sockets

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -24,10 +24,7 @@ jobs:
           - magento-version: "2.4.8-p5"
             php-version: "8.4"
             search-engine-name: "opensearch"
-          - magento-version: "2.4.9-beta1"
-            php-version: "8.4"
-            search-engine-name: "opensearch"
-          - magento-version: "2.4.9-beta1"
+          - magento-version: "2.4.9"
             php-version: "8.5"
             search-engine-name: "opensearch"
 

--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   magento-compatibility-matrix:
     name: Magento ${{ matrix.magento-version }} with PHP ${{ matrix.php-version }}
@@ -60,7 +63,7 @@ jobs:
           path: mageforge
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl, gd, xml, soap, zip, bcmath, pdo_mysql, curl, sockets

--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - magento-version: "2.4.7-p9"
+          - magento-version: "2.4.7-p10"
             php-version: "8.3"
             search-engine-name: "opensearch"
-          - magento-version: "2.4.8-p4"
+          - magento-version: "2.4.8-p5"
             php-version: "8.4"
             search-engine-name: "opensearch"
           - magento-version: "2.4.9-beta1"

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ env.PHP_VERSION }}
+          tools: composer:v2
 
       - name: Install Magento Coding Standard
         run: composer create-project magento/magento-coding-standard --stability=dev /tmp/magento-coding-standard

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: mageforge
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: "8.4"
           extensions: mbstring, intl, gd, xml, soap, zip, bcmath, pdo_mysql, curl, sockets
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.composer/cache/files
           key: ${{ runner.os }}-composer-2.4.8-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           # The GitHub token for creating releases and pull requests
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           # The GitHub token for creating releases and pull requests
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
           # Path to release-please-config.json
           config-file: release-please-config.json
-          
+
           # Path to .release-please-manifest.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve reliability, security, and keep dependencies up to date. The main changes include pinning action versions to specific commit hashes, updating Magento and PHP versions in compatibility tests, and improving health checks for MySQL in functional tests.

**Workflow dependency and security improvements:**

* All GitHub Actions (`actions/checkout`, `shivammathur/setup-php`, `actions/cache`, `actions/labeler`, `googleapis/release-please-action`) are now pinned to specific commit hashes for better security and reproducibility. [[1]](diffhunk://#diff-10c0cd6a4f95e78dd4975968a27901c644f6e36a8a75147e3fb86d08e1c1831bL20-R20) [[2]](diffhunk://#diff-f621c7ec73ae73c758a64d5f030f2062fc73f50676d953035650636c052aac3fL17-R23) [[3]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L40-R53) [[4]](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L17-R17) [[5]](diffhunk://#diff-7b831cbf8f27dd7daf6ac7b252f87382fc9d2342099845a08c0fc95a33670357L45-R50) [[6]](diffhunk://#diff-e4d2e5901ca4112dba62fc88b0d80176fe856ba318e15b75a55b13cb6ae9a9ccL63-R63)

**Magento compatibility matrix updates:**

* Updated tested Magento versions in `.github/workflows/magento-compatibility.yml` to `"2.4.7-p10"`, `"2.4.8-p5"`, and `"2.4.9"`, and corresponding PHP versions, ensuring the workflow tests against the latest supported versions.

**Functional test reliability:**

* Improved MySQL container health check in `.github/workflows/functional-tests.yml` by making the health command more robust, increasing the number of retries, and adding a start period to reduce flakiness.

**General workflow improvements:**

* Added explicit `permissions` for the `magento-compatibility.yml` workflow to follow GitHub best practices.

**PHP tooling setup enhancements:**

* Ensured `composer:v2` is always installed with PHP setup steps in relevant workflows. [[1]](diffhunk://#diff-f621c7ec73ae73c758a64d5f030f2062fc73f50676d953035650636c052aac3fL17-R23) [[2]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L40-R53)