### PR TITLE
fix: cast render result to string in InspectorHints

### DIFF
--- a/src/Model/TemplateEngine/Decorator/InspectorHints.php
+++ b/src/Model/TemplateEngine/Decorator/InspectorHints.php
@@ -124,7 +124,7 @@ class InspectorHints implements TemplateEngineInterface
     {
         // Measure render time
         $startTime = hrtime(true);
-        $result = $this->subject->render($block, $templateFile, $dictionary);
+        $result = (string) $this->subject->render($block, $templateFile, $dictionary);
         $endTime = hrtime(true);
 
         if (!$this->showBlockHints) {


### PR DESCRIPTION
This pull request makes a minor update to the `render` method in `InspectorHints.php` to ensure the result is always a string. The change casts the output of the underlying `render` call to a string, which helps prevent type issues.

* Ensured that the result of `$this->subject->render` is explicitly cast to a string in the `render` method of `InspectorHints.php` to guarantee consistent return types.