### PR TITLE
feat: add new color group styles to toolbar

### DIFF
--- a/src/Service/Hyva/CompatibilityChecker.php
+++ b/src/Service/Hyva/CompatibilityChecker.php
@@ -203,7 +203,7 @@ class CompatibilityChecker
             return '<fg=green>✓ Compatible</>';
         }
 
-        if ($moduleData['compatible'] && $moduleData['hasWarnings']) {
+        if ($moduleData['compatible']) {
             return '<fg=yellow>⚠ Warnings</>';
         }
 

--- a/src/view/frontend/web/css/toolbar.css
+++ b/src/view/frontend/web/css/toolbar.css
@@ -22,7 +22,11 @@
     --mageforge-color-slate-400: #94a3b8;
     --mageforge-color-orange: #fb923c;
     --mageforge-color-pink: #C850C0;
+    --mageforge-color-purple: #a855f7;
     --mageforge-color-amber: #edb04d;
+    --mageforge-group-color-wcag: var(--mageforge-color-purple);
+    --mageforge-group-color-html-quality: var(--mageforge-color-blue);
+    --mageforge-group-color-performance: var(--mageforge-color-orange);
     --mageforge-color-amber-alpha-15: rgba(237, 176, 77, 0.15);
     --mageforge-color-amber-alpha-35: rgba(237, 176, 77, 0.35);
     --mageforge-bg-dark: rgba(15, 23, 42, 0.98);
@@ -332,13 +336,14 @@
     font-size: 11px;
     line-height: 1.3;
     user-select: text;
-    cursor: text;
+    cursor: default;
 }
 
 .mageforge-toolbar-menu-desc.mageforge-active {
     color: var(--mageforge-color-orange);
     font-size: 12px;
     user-select: text;
+    cursor: default;
 }
 
 .mageforge-toolbar-menu-label-row {
@@ -417,7 +422,31 @@
     text-transform: uppercase;
     transition: color 0.15s ease;
     letter-spacing: 0.08em;
-    color: var(--mageforge-color-orange);
+    color: var(--mageforge-color-slate-400);
+}
+
+.mageforge-toolbar-menu-group[data-group-key="wcag"] .mageforge-toolbar-menu-group-label {
+    color: var(--mageforge-group-color-wcag);
+}
+
+.mageforge-toolbar-menu-group[data-group-key="html-quality"] .mageforge-toolbar-menu-group-label {
+    color: var(--mageforge-group-color-html-quality);
+}
+
+.mageforge-toolbar-menu-group[data-group-key="performance"] .mageforge-toolbar-menu-group-label {
+    color: var(--mageforge-group-color-performance);
+}
+
+.mageforge-toolbar-menu-item[data-group="wcag"] .mageforge-toolbar-menu-icon {
+    color: var(--mageforge-group-color-wcag);
+}
+
+.mageforge-toolbar-menu-item[data-group="html-quality"] .mageforge-toolbar-menu-icon {
+    color: var(--mageforge-group-color-html-quality);
+}
+
+.mageforge-toolbar-menu-item[data-group="performance"] .mageforge-toolbar-menu-icon {
+    color: var(--mageforge-group-color-performance);
 }
 
 .mageforge-toolbar-menu-group-chevron {

--- a/src/view/frontend/web/css/toolbar.css
+++ b/src/view/frontend/web/css/toolbar.css
@@ -22,9 +22,9 @@
     --mageforge-color-slate-400: #94a3b8;
     --mageforge-color-orange: #fb923c;
     --mageforge-color-pink: #C850C0;
-    --mageforge-toolbar-purple: #a855f7;
+    --mageforge-color-purple: #a855f7;
     --mageforge-color-amber: #edb04d;
-    --mageforge-group-color-wcag: var(--mageforge-toolbar-purple);
+    --mageforge-group-color-wcag: var(--mageforge-color-purple);
     --mageforge-group-color-html-quality: var(--mageforge-color-blue);
     --mageforge-group-color-performance: var(--mageforge-color-orange);
     --mageforge-color-amber-alpha-15: rgba(237, 176, 77, 0.15);
@@ -436,15 +436,15 @@
     color: var(--mageforge-group-color-performance);
 }
 
-.mageforge-toolbar-menu-item[data-group="wcag"] .mageforge-toolbar-menu-icon {
+.mageforge-toolbar-menu-item[data-group-key="wcag"] .mageforge-toolbar-menu-icon {
     color: var(--mageforge-group-color-wcag);
 }
 
-.mageforge-toolbar-menu-item[data-group="html-quality"] .mageforge-toolbar-menu-icon {
+.mageforge-toolbar-menu-item[data-group-key="html-quality"] .mageforge-toolbar-menu-icon {
     color: var(--mageforge-group-color-html-quality);
 }
 
-.mageforge-toolbar-menu-item[data-group="performance"] .mageforge-toolbar-menu-icon {
+.mageforge-toolbar-menu-item[data-group-key="performance"] .mageforge-toolbar-menu-icon {
     color: var(--mageforge-group-color-performance);
 }
 

--- a/src/view/frontend/web/css/toolbar.css
+++ b/src/view/frontend/web/css/toolbar.css
@@ -343,7 +343,6 @@
     color: var(--mageforge-color-orange);
     font-size: 12px;
     user-select: text;
-    cursor: default;
 }
 
 .mageforge-toolbar-menu-label-row {

--- a/src/view/frontend/web/css/toolbar.css
+++ b/src/view/frontend/web/css/toolbar.css
@@ -22,9 +22,9 @@
     --mageforge-color-slate-400: #94a3b8;
     --mageforge-color-orange: #fb923c;
     --mageforge-color-pink: #C850C0;
-    --mageforge-color-purple: #a855f7;
+    --mageforge-toolbar-purple: #a855f7;
     --mageforge-color-amber: #edb04d;
-    --mageforge-group-color-wcag: var(--mageforge-color-purple);
+    --mageforge-group-color-wcag: var(--mageforge-toolbar-purple);
     --mageforge-group-color-html-quality: var(--mageforge-color-blue);
     --mageforge-group-color-performance: var(--mageforge-color-orange);
     --mageforge-color-amber-alpha-15: rgba(237, 176, 77, 0.15);
@@ -409,7 +409,7 @@
     margin-bottom: 4px;
 }
 
-.mageforge-toolbar-menu-group-header:hover .mageforge-toolbar-menu-group-label,
+.mageforge-toolbar-menu-group .mageforge-toolbar-menu-group-header:hover .mageforge-toolbar-menu-group-label,
 .mageforge-toolbar-menu-group-header:hover .mageforge-toolbar-menu-group-chevron {
     color: var(--mageforge-color-white);
 }

--- a/src/view/frontend/web/js/toolbar/ui.js
+++ b/src/view/frontend/web/js/toolbar/ui.js
@@ -264,7 +264,8 @@ export const uiMethods = {
                 audit.icon,
                 audit.label,
                 audit.description,
-                () => this.runAudit(audit.key)
+                () => this.runAudit(audit.key),
+                key
             ));
         });
 
@@ -282,11 +283,12 @@ export const uiMethods = {
      * @param {Function} callback
      * @return {HTMLButtonElement}
      */
-    createMenuItem(key, icon, label, description, callback) {
+    createMenuItem(key, icon, label, description, callback, groupKey = null) {
         const item = document.createElement('button');
         item.type = 'button';
         item.className = 'mageforge-toolbar-menu-item';
         item.dataset.auditKey = key;
+        if (groupKey) item.dataset.group = groupKey;
         item.setAttribute('aria-pressed', 'false');
 
         const iconEl = document.createElement('span');

--- a/src/view/frontend/web/js/toolbar/ui.js
+++ b/src/view/frontend/web/js/toolbar/ui.js
@@ -289,7 +289,7 @@ export const uiMethods = {
         item.type = 'button';
         item.className = 'mageforge-toolbar-menu-item';
         item.dataset.auditKey = key;
-        if (groupKey) item.dataset.group = groupKey;
+        if (groupKey) item.dataset.groupKey = groupKey;
         item.setAttribute('aria-pressed', 'false');
 
         const iconEl = document.createElement('span');

--- a/src/view/frontend/web/js/toolbar/ui.js
+++ b/src/view/frontend/web/js/toolbar/ui.js
@@ -281,6 +281,7 @@ export const uiMethods = {
      * @param {string} label
      * @param {string} description
      * @param {Function} callback
+     * @param {?string} groupKey - Optional parent group key for the item
      * @return {HTMLButtonElement}
      */
     createMenuItem(key, icon, label, description, callback, groupKey = null) {


### PR DESCRIPTION
This pull request updates the toolbar UI to support group-based color coding for audit menu items and improves accessibility and clarity in the interface. The main changes include the addition of new CSS variables and rules for group colors, passing group keys through the UI code, and minor cursor style adjustments.

**Toolbar group color coding and UI improvements:**

* Added new CSS variables for group colors (`wcag`, `html-quality`, `performance`) and mapped them to specific color values for consistent visual grouping.
* Updated CSS to color toolbar group labels and icons according to their group using data attributes, making it easier to visually distinguish between different audit categories.
* Modified the `createMenuItem` JavaScript method to accept and set a `groupKey` as a data attribute, enabling group-based styling in the toolbar.
* Updated the code that creates menu items to pass the group key when constructing each item, ensuring the correct group information is available for styling.

**Minor UI/UX adjustments:**

* Changed the cursor style for menu descriptions from `text` to `default` for better usability and consistency.