### PR TITLE
fix: enhance cache cleaning in InspectorCommand to include layout and…

### DIFF
--- a/src/Console/Command/Dev/InspectorCommand.php
+++ b/src/Console/Command/Dev/InspectorCommand.php
@@ -207,7 +207,7 @@ class InspectorCommand extends AbstractCommand
     }
 
     /**
-     * Clean config cache
+     * Clean relevant caches after changing inspector status
      *
      * @return void
      */

--- a/src/Console/Command/Dev/InspectorCommand.php
+++ b/src/Console/Command/Dev/InspectorCommand.php
@@ -213,7 +213,7 @@ class InspectorCommand extends AbstractCommand
      */
     private function cleanCache(): void
     {
-        $this->cacheManager->clean(['config']);
-        $this->io->writeln('<comment>Config cache cleaned</comment>');
+        $this->cacheManager->clean(['config', 'layout', 'full_page', 'block_html']);
+        $this->io->writeln('<comment>Config, layout, full page & block HTML cache cleaned</comment>');
     }
 }

--- a/src/Console/Command/Dev/InspectorCommand.php
+++ b/src/Console/Command/Dev/InspectorCommand.php
@@ -214,6 +214,6 @@ class InspectorCommand extends AbstractCommand
     private function cleanCache(): void
     {
         $this->cacheManager->clean(['config', 'layout', 'full_page', 'block_html']);
-        $this->io->writeln('<comment>Config, layout, full page & block HTML cache cleaned</comment>');
+        $this->io->writeln('<comment>Config, layout, full page & block HTML caches cleaned</comment>');
     }
 }


### PR DESCRIPTION
This pull request updates the cache cleaning logic in the `InspectorCommand` to clear additional cache types, ensuring a more thorough cache reset when the command is executed.

Cache management improvements:

* Expanded the cache types cleared in the `cleanCache` method from only `config` to also include `layout`, `full_page`, and `block_html`, and updated the output message accordingly in `InspectorCommand.php`.… full page caches