### PR TITLE
PHP 8.5 compatibility: Method ReflectionProperty::setAccessible is deprecated

### DIFF
--- a/src/Service/Inspector/Cache/BlockCacheCollector.php
+++ b/src/Service/Inspector/Cache/BlockCacheCollector.php
@@ -142,7 +142,6 @@ class BlockCacheCollector
         if (property_exists($block, '_isScopePrivate')) {
             try {
                 $reflection = new \ReflectionProperty($block, '_isScopePrivate');
-                $reflection->setAccessible(true);
                 $isScopePrivate = $reflection->getValue($block);
                 if ($isScopePrivate === true) {
                     return true;


### PR DESCRIPTION
When trying to use theme inspector with Magento 2.4.9 and PHP 8.5 I've got en exception:

```
Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1
```

Since this project doesn't support PHP 8.0, this is not a BC.

<details>
<summary>View Screenshot</summary>
<img width="1269" height="854" alt="image" src="https://github.com/user-attachments/assets/055cad2c-d472-4ee9-b0b7-32b04b1a22bf" />
</details>
