### PR TITLE
fix: Validate theme code length in ThemeSuggester to prevent exceeding character limit

### DIFF
--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -137,6 +137,11 @@ abstract class AbstractCommand extends Command
         ThemeSuggester $themeSuggester,
         OutputInterface $output,
     ): ?string {
+        if (strlen($invalidTheme) > 255) {
+            $this->io->error("Theme name '$invalidTheme' is too long (max. 255 characters).");
+            return null;
+        }
+
         $suggestions = $themeSuggester->findSimilarThemes($invalidTheme);
 
         // No suggestions found

--- a/src/Model/ThemeList.php
+++ b/src/Model/ThemeList.php
@@ -10,8 +10,6 @@ use Magento\Theme\Model\Theme;
 class ThemeList
 {
     /**
-     * Constructor
-     *
      * @param MagentoThemeList $magentoThemeList
      */
     public function __construct(

--- a/src/Service/ThemeSuggester.php
+++ b/src/Service/ThemeSuggester.php
@@ -43,21 +43,32 @@ class ThemeSuggester
             return [];
         }
 
+        if (strlen($invalidTheme) > 255) {
+            return [];
+        }
+
+        $normalizedInput = strtolower($invalidTheme);
         $themes = $this->themeList->getAllThemes();
-        $threshold = (int) (strlen($invalidTheme) / 3);
+        $threshold = (int) (strlen($normalizedInput) / 3);
         $suggestions = [];
 
         foreach ($themes as $theme) {
             $themeCode = $theme->getCode();
+            $normalizedCode = strtolower($themeCode);
+            $isSubstringMatch = str_contains($normalizedCode, $normalizedInput);
 
+            // Only skip levenshtein for overlong codes, still allow substring match
             if (strlen($themeCode) > 255) {
+                if ($isSubstringMatch) {
+                    $suggestions[$themeCode] = PHP_INT_MAX;
+                }
                 continue;
             }
 
-            $distance = levenshtein(strtolower($invalidTheme), strtolower($themeCode));
+            $distance = levenshtein($normalizedInput, $normalizedCode);
 
             // Accept if: distance ≤ 1/3 of input length OR substring match (case-insensitive)
-            if ($distance <= $threshold || str_contains(strtolower($themeCode), strtolower($invalidTheme))) {
+            if ($distance <= $threshold || $isSubstringMatch) {
                 $suggestions[$themeCode] = $distance;
             }
         }

--- a/src/Service/ThemeSuggester.php
+++ b/src/Service/ThemeSuggester.php
@@ -49,6 +49,11 @@ class ThemeSuggester
 
         foreach ($themes as $theme) {
             $themeCode = $theme->getCode();
+
+            if (strlen($themeCode) > 255) {
+                continue;
+            }
+
             $distance = levenshtein(strtolower($invalidTheme), strtolower($themeCode));
 
             // Accept if: distance ≤ 1/3 of input length OR substring match (case-insensitive)


### PR DESCRIPTION
This pull request introduces a validation improvement to the theme suggestion logic and a minor documentation cleanup. The most important changes are summarized below:

### Theme suggestion improvements

* In `ThemeSuggester.php`, the `findSimilarThemes` method now skips any theme whose code exceeds 255 characters, preventing unnecessary computation and potential issues with overly long theme codes.

### Documentation cleanup

* In `ThemeList.php`, removed the redundant "Constructor" comment from the constructor docblock for clarity.