### PR TITLE
feat: Add structured data audit features including JSON-LD and Schema…

### DIFF
--- a/src/view/frontend/web/css/toolbar.css
+++ b/src/view/frontend/web/css/toolbar.css
@@ -14,6 +14,7 @@
 @import url("toolbar/_menu.css");
 @import url("toolbar/_groups.css");
 @import url("toolbar/_findings.css");
+@import url("toolbar/_jsonld-viewer.css");
 @import url("toolbar/_highlights.css");
 @import url("toolbar/_feedback.css");
 @import url("toolbar/_animations.css");

--- a/src/view/frontend/web/css/toolbar/_groups.css
+++ b/src/view/frontend/web/css/toolbar/_groups.css
@@ -104,7 +104,7 @@
 
 .mageforge-toolbar-tab-btn[data-tab="structured-data"].mageforge-tab-active {
   color: var(--mageforge-group-color-structured-data);
-  background: rgba(99, 102, 241, 0.1);
+  background: rgba(217, 70, 239, 0.1);
 }
 
 /* Left-edge indicator bar on active tab */
@@ -147,6 +147,10 @@
 
 .mageforge-toolbar-tab-btn[data-tab="seo"] .mageforge-tab-icon {
   color: var(--mageforge-group-color-seo);
+}
+
+.mageforge-toolbar-tab-btn[data-tab="structured-data"] .mageforge-tab-icon {
+  color: var(--mageforge-group-color-structured-data);
 }
 
 .mageforge-tab-label {
@@ -582,4 +586,9 @@
 .mageforge-toolbar-menu-item[data-group-key="seo"]
   .mageforge-toolbar-menu-icon {
   color: var(--mageforge-group-color-seo);
+}
+
+.mageforge-toolbar-menu-item[data-group-key="structured-data"]
+  .mageforge-toolbar-menu-icon {
+  color: var(--mageforge-group-color-structured-data);
 }

--- a/src/view/frontend/web/css/toolbar/_groups.css
+++ b/src/view/frontend/web/css/toolbar/_groups.css
@@ -102,6 +102,11 @@
   background: rgba(20, 184, 166, 0.1);
 }
 
+.mageforge-toolbar-tab-btn[data-tab="structured-data"].mageforge-tab-active {
+  color: var(--mageforge-group-color-structured-data);
+  background: rgba(99, 102, 241, 0.1);
+}
+
 /* Left-edge indicator bar on active tab */
 
 .mageforge-toolbar-tab-btn.mageforge-tab-active::before {

--- a/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
+++ b/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
@@ -1,0 +1,218 @@
+/**
+ * MageForge Toolbar – JSON-LD Viewer styles
+ *
+ * @package OpenForgeProject\MageForge
+ * @license GPL-3.0
+ */
+
+.mageforge-jsonld-viewer-open {
+  padding: 0 !important;
+  border-top: none !important;
+}
+
+.mageforge-jsonld-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--mageforge-border-color);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.mageforge-jsonld-count {
+  color: var(--mageforge-text-secondary, rgba(148, 163, 184, 0.8));
+}
+
+.mageforge-jsonld-errors {
+  color: var(--mageforge-color-red);
+  background: var(--mageforge-color-red-alpha-15);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.mageforge-jsonld-empty {
+  padding: 12px;
+  margin: 0;
+  font-size: 11px;
+  color: var(--mageforge-color-amber);
+  font-style: italic;
+}
+
+.mageforge-jsonld-block {
+  border-bottom: 1px solid var(--mageforge-border-color);
+}
+
+.mageforge-jsonld-block:last-child {
+  border-bottom: none;
+}
+
+.mageforge-jsonld-block--error .mageforge-jsonld-block-header {
+  color: var(--mageforge-color-red);
+}
+
+.mageforge-jsonld-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--mageforge-text-primary, rgba(248, 250, 252, 0.9));
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--mageforge-font-family);
+  transition: background 0.15s ease;
+}
+
+.mageforge-jsonld-block-header:hover {
+  background: var(--mageforge-surface-glass-hover);
+}
+
+.mageforge-jsonld-block-type {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mageforge-jsonld-chevron {
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: transform 0.2s ease;
+}
+
+.mageforge-jsonld-chevron--open {
+  transform: rotate(180deg);
+  opacity: 0.9;
+}
+
+.mageforge-jsonld-block-content {
+  padding: 0 12px 10px;
+  position: relative;
+}
+
+.mageforge-jsonld-parse-error {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  background: var(--mageforge-color-red-alpha-15);
+  border: 1px solid var(--mageforge-color-red-alpha-35);
+  border-radius: 4px;
+  font-size: 10px;
+  color: var(--mageforge-color-red);
+  word-break: break-word;
+}
+
+.mageforge-jsonld-pre {
+  margin: 0;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--mageforge-border-color);
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 260px;
+  font-size: 10px;
+  line-height: 1.6;
+}
+
+.mageforge-jsonld-pre code {
+  font-family:
+    "JetBrains Mono", "Fira Code", "Cascadia Code", Consolas, "Courier New",
+    monospace;
+  color: var(--mageforge-text-primary, rgba(248, 250, 252, 0.9));
+  white-space: pre;
+}
+
+.mageforge-jsonld-copy-btn {
+  display: block;
+  margin-top: 6px;
+  padding: 3px 10px;
+  background: var(--mageforge-surface-glass);
+  border: 1px solid var(--mageforge-border-glass);
+  border-radius: 4px;
+  color: var(--mageforge-color-slate-400);
+  font-size: 10px;
+  font-family: var(--mageforge-font-family);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.mageforge-jsonld-copy-btn:hover {
+  background: var(--mageforge-surface-glass-hover);
+  color: var(--mageforge-color-white);
+}
+
+/* ── Schema.org Viewer ──────────────────────────────────────────────────── */
+
+.mageforge-schema-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: rgba(99, 102, 241, 0.15);
+  color: #818cf8;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  line-height: 1.5;
+}
+
+.mageforge-schema-badge--rdfa {
+  background: rgba(251, 146, 60, 0.15);
+  color: var(--mageforge-color-orange);
+  border-color: rgba(251, 146, 60, 0.3);
+}
+
+.mageforge-schema-type-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 6px;
+  border-bottom: 1px solid var(--mageforge-border-color);
+  margin-bottom: 4px;
+}
+
+.mageforge-schema-type-link {
+  font-size: 10px;
+  color: #818cf8;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.mageforge-schema-type-link:hover {
+  text-decoration: underline;
+}
+
+.mageforge-schema-props {
+  margin: 4px 0 0;
+  display: grid;
+  grid-template-columns: minmax(80px, max-content) 1fr;
+  gap: 2px 10px;
+  align-items: baseline;
+}
+
+.mageforge-schema-prop-name {
+  font-size: 10px;
+  font-weight: 600;
+  color: #818cf8;
+  white-space: nowrap;
+  padding: 2px 0;
+}
+
+.mageforge-schema-prop-value {
+  font-size: 10px;
+  color: var(--mageforge-text-primary, rgba(248, 250, 252, 0.9));
+  word-break: break-word;
+  padding: 2px 0;
+  margin: 0;
+}
+
+.mageforge-schema-prop-nested {
+  color: var(--mageforge-color-slate-400);
+  font-style: italic;
+}

--- a/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
+++ b/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
@@ -225,9 +225,9 @@
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  background: var(--mageforge-color-indigo-alpha-15);
-  color: var(--mageforge-color-indigo-light);
-  border: 1px solid var(--mageforge-color-indigo-alpha-30);
+  background: var(--mageforge-color-fuchsia-alpha-15);
+  color: var(--mageforge-color-fuchsia-light);
+  border: 1px solid var(--mageforge-color-fuchsia-alpha-30);
   line-height: 1.5;
 }
 
@@ -248,7 +248,7 @@
 
 .mageforge-schema-type-link {
   font-size: 10px;
-  color: var(--mageforge-color-indigo-light);
+  color: var(--mageforge-color-fuchsia-light);
   text-decoration: none;
   word-break: break-all;
 }
@@ -268,7 +268,7 @@
 .mageforge-schema-prop-name {
   font-size: 10px;
   font-weight: 600;
-  color: var(--mageforge-color-indigo-light);
+  color: var(--mageforge-color-fuchsia-light);
   white-space: nowrap;
   padding: 2px 0;
 }

--- a/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
+++ b/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
@@ -225,9 +225,9 @@
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  background: rgba(99, 102, 241, 0.15);
-  color: #818cf8;
-  border: 1px solid rgba(99, 102, 241, 0.3);
+  background: var(--mageforge-color-indigo-alpha-15);
+  color: var(--mageforge-color-indigo-light);
+  border: 1px solid var(--mageforge-color-indigo-alpha-30);
   line-height: 1.5;
 }
 
@@ -248,7 +248,7 @@
 
 .mageforge-schema-type-link {
   font-size: 10px;
-  color: #818cf8;
+  color: var(--mageforge-color-indigo-light);
   text-decoration: none;
   word-break: break-all;
 }
@@ -268,7 +268,7 @@
 .mageforge-schema-prop-name {
   font-size: 10px;
   font-weight: 600;
-  color: #818cf8;
+  color: var(--mageforge-color-indigo-light);
   white-space: nowrap;
   padding: 2px 0;
 }

--- a/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
+++ b/src/view/frontend/web/css/toolbar/_jsonld-viewer.css
@@ -31,6 +31,13 @@
   border-radius: 4px;
 }
 
+.mageforge-jsonld-warnings {
+  color: var(--mageforge-color-amber);
+  background: var(--mageforge-color-amber-alpha-15);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
 .mageforge-jsonld-empty {
   padding: 12px;
   margin: 0;
@@ -49,6 +56,68 @@
 
 .mageforge-jsonld-block--error .mageforge-jsonld-block-header {
   color: var(--mageforge-color-red);
+}
+
+.mageforge-jsonld-block--warning .mageforge-jsonld-block-header {
+  color: var(--mageforge-color-amber);
+}
+
+/* Validation badge in block header */
+.mageforge-jsonld-val-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1.5;
+  vertical-align: middle;
+}
+
+.mageforge-jsonld-val-badge--error {
+  background: var(--mageforge-color-red-alpha-15);
+  color: var(--mageforge-color-red);
+  border: 1px solid var(--mageforge-color-red-alpha-35);
+}
+
+.mageforge-jsonld-val-badge--warning {
+  background: var(--mageforge-color-amber-alpha-15);
+  color: var(--mageforge-color-amber);
+  border: 1px solid var(--mageforge-color-amber-alpha-35);
+}
+
+/* Validation issues list */
+.mageforge-jsonld-issues {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mageforge-jsonld-issue {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.mageforge-jsonld-issue svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.mageforge-jsonld-issue--error {
+  color: var(--mageforge-color-red);
+}
+
+.mageforge-jsonld-issue--warning {
+  color: var(--mageforge-color-amber);
 }
 
 .mageforge-jsonld-block-header {

--- a/src/view/frontend/web/css/toolbar/_variables.css
+++ b/src/view/frontend/web/css/toolbar/_variables.css
@@ -38,11 +38,11 @@
   --mageforge-group-color-html-quality: var(--mageforge-color-blue);
   --mageforge-group-color-performance: var(--mageforge-color-orange);
   --mageforge-group-color-seo: #14b8a6;
-  --mageforge-group-color-structured-data: #6366f1;
-  --mageforge-color-indigo: #6366f1;
-  --mageforge-color-indigo-alpha-15: rgba(99, 102, 241, 0.15);
-  --mageforge-color-indigo-alpha-30: rgba(99, 102, 241, 0.3);
-  --mageforge-color-indigo-light: #818cf8;
+  --mageforge-group-color-structured-data: #d946ef;
+  --mageforge-color-fuchsia: #d946ef;
+  --mageforge-color-fuchsia-alpha-15: rgba(217, 70, 239, 0.15);
+  --mageforge-color-fuchsia-alpha-30: rgba(217, 70, 239, 0.3);
+  --mageforge-color-fuchsia-light: #e879f9;
 
   /* Backgrounds */
   --mageforge-bg-dark: rgba(15, 23, 42, 0.98);

--- a/src/view/frontend/web/css/toolbar/_variables.css
+++ b/src/view/frontend/web/css/toolbar/_variables.css
@@ -39,6 +39,10 @@
   --mageforge-group-color-performance: var(--mageforge-color-orange);
   --mageforge-group-color-seo: #14b8a6;
   --mageforge-group-color-structured-data: #6366f1;
+  --mageforge-color-indigo: #6366f1;
+  --mageforge-color-indigo-alpha-15: rgba(99, 102, 241, 0.15);
+  --mageforge-color-indigo-alpha-30: rgba(99, 102, 241, 0.3);
+  --mageforge-color-indigo-light: #818cf8;
 
   /* Backgrounds */
   --mageforge-bg-dark: rgba(15, 23, 42, 0.98);

--- a/src/view/frontend/web/css/toolbar/_variables.css
+++ b/src/view/frontend/web/css/toolbar/_variables.css
@@ -38,6 +38,7 @@
   --mageforge-group-color-html-quality: var(--mageforge-color-blue);
   --mageforge-group-color-performance: var(--mageforge-color-orange);
   --mageforge-group-color-seo: #14b8a6;
+  --mageforge-group-color-structured-data: #6366f1;
 
   /* Backgrounds */
   --mageforge-bg-dark: rgba(15, 23, 42, 0.98);

--- a/src/view/frontend/web/js/toolbar/audits/index.js
+++ b/src/view/frontend/web/js/toolbar/audits/index.js
@@ -38,7 +38,9 @@ import renderBlockingScripts from "./render-blocking-scripts.js";
 import seoDuplicateMeta from "./seo-duplicate-meta.js";
 import seoHeadingHierarchy from "./seo-heading-hierarchy.js";
 import seoMissingCanonical from "./seo-missing-canonical.js";
-import seoMissingJsonLd from "./seo-missing-json-ld.js";
+import structuredMissingJsonLd from "./seo-missing-json-ld.js";
+import structuredJsonLdViewer from "./seo-json-ld-viewer.js";
+import schemaOrgViewer from "./schema-org-viewer.js";
 import seoMissingLang from "./seo-missing-lang.js";
 import seoMissingMetaDescription from "./seo-missing-meta-description.js";
 import seoMissingTitle from "./seo-missing-title.js";
@@ -50,6 +52,7 @@ import unsafeBlankTarget from "./unsafe-blank-target.js";
 /** @type {AuditGroup[]} */
 export const auditGroups = [
   { key: "seo", label: "SEO" },
+  { key: "structured-data", label: "Structured Data" },
   { key: "performance", label: "Performance" },
   { key: "html-quality", label: "HTML Quality" },
   { key: "wcag", label: "Accessibility" },
@@ -79,6 +82,8 @@ export const audits = [
   { ...seoMissingCanonical, group: "seo" },
   { ...seoMissingLang, group: "seo" },
   { ...seoHeadingHierarchy, group: "seo" },
-  { ...seoMissingJsonLd, group: "seo" },
   { ...seoDuplicateMeta, group: "seo" },
+  { ...structuredMissingJsonLd, group: "structured-data" },
+  { ...structuredJsonLdViewer, group: "structured-data" },
+  { ...schemaOrgViewer, group: "structured-data" },
 ];

--- a/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
@@ -1,0 +1,242 @@
+/**
+ * MageForge Toolbar Audit – Schema.org Microdata Viewer
+ *
+ * Reads all schema.org microdata (itemscope / itemtype / itemprop attributes)
+ * from the current page DOM and renders a structured tree view in the findings
+ * panel. Also detects RDFa (typeof / property attributes).
+ *
+ * Page-level audit: no DOM element highlighting, findings panel shows the data.
+ */
+
+const KEY = "schema-org-viewer";
+
+/**
+ * Recursively collect microdata properties from an itemscope element.
+ *
+ * @param {Element} root
+ * @returns {{ type: string, props: Array<{name: string, value: string, nested?: object}> }}
+ */
+function collectMicrodata(root) {
+  const type = root.getAttribute("itemtype") ?? "";
+  const props = [];
+
+  root.querySelectorAll("[itemprop]").forEach((el) => {
+    // Skip deeply nested items already handled by their own itemscope
+    const closestScope = el.parentElement?.closest("[itemscope]");
+    if (closestScope && closestScope !== root) return;
+
+    const name = el.getAttribute("itemprop") ?? "";
+    let value = "";
+    let nested = null;
+
+    if (el.hasAttribute("itemscope")) {
+      nested = collectMicrodata(el);
+    } else if (el.tagName === "META") {
+      value = el.getAttribute("content") ?? "";
+    } else if (el.tagName === "LINK") {
+      value = el.getAttribute("href") ?? "";
+    } else if (el.tagName === "IMG") {
+      value = el.getAttribute("src") ?? "";
+    } else if (el.tagName === "TIME") {
+      value = el.getAttribute("datetime") ?? el.textContent.trim();
+    } else if (el.tagName === "A") {
+      value = el.getAttribute("href") ?? el.textContent.trim();
+    } else {
+      value = el.textContent.trim().slice(0, 120);
+    }
+
+    props.push({ name, value, nested });
+  });
+
+  return { type, props };
+}
+
+/**
+ * Collect RDFa-annotated root elements (typeof attribute on non-nested elements).
+ *
+ * @returns {Array<{type: string, el: Element}>}
+ */
+function collectRdfa() {
+  return Array.from(document.querySelectorAll("[typeof]"))
+    .filter((el) => !el.parentElement?.closest("[typeof]"))
+    .map((el) => ({
+      type: el.getAttribute("typeof") ?? "",
+      el,
+    }));
+}
+
+/**
+ * Build a DOM tree for a collected microdata item.
+ *
+ * @param {{ type: string, props: Array }} item
+ * @param {string} badgeLabel
+ * @returns {HTMLElement}
+ */
+function buildBlockDOM(item, badgeLabel) {
+  const typeShort = item.type.replace(/https?:\/\/schema\.org\//i, "");
+
+  const block = document.createElement("div");
+  block.className = "mageforge-jsonld-block";
+
+  const header = document.createElement("button");
+  header.type = "button";
+  header.className = "mageforge-jsonld-block-header";
+  header.setAttribute("aria-expanded", "false");
+  header.innerHTML = `
+    <span class="mageforge-jsonld-block-type">
+      <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>
+      ${typeShort || "Unknown Type"}
+      <span class="mageforge-schema-badge">${badgeLabel}</span>
+    </span>
+    <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+  `;
+
+  const content = document.createElement("div");
+  content.className = "mageforge-jsonld-block-content";
+  content.hidden = true;
+
+  if (item.type) {
+    const typeRow = document.createElement("div");
+    typeRow.className = "mageforge-schema-type-row";
+    typeRow.innerHTML = `<span class="mageforge-schema-prop-name">@type</span><a class="mageforge-schema-type-link" href="${item.type}" target="_blank" rel="noopener noreferrer">${item.type}</a>`;
+    content.appendChild(typeRow);
+  }
+
+  if (item.props.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "mageforge-jsonld-empty";
+    empty.textContent = "No itemprop attributes found.";
+    content.appendChild(empty);
+  } else {
+    const table = document.createElement("dl");
+    table.className = "mageforge-schema-props";
+    item.props.forEach(({ name, value, nested }) => {
+      const dt = document.createElement("dt");
+      dt.className = "mageforge-schema-prop-name";
+      dt.textContent = name;
+      table.appendChild(dt);
+
+      const dd = document.createElement("dd");
+      dd.className = "mageforge-schema-prop-value";
+      if (nested) {
+        const nestedType = nested.type.replace(/https?:\/\/schema\.org\//i, "");
+        dd.textContent = `[${nestedType || "Nested item"} — ${nested.props.length} prop${nested.props.length !== 1 ? "s" : ""}]`;
+        dd.classList.add("mageforge-schema-prop-nested");
+      } else {
+        dd.textContent = value || "—";
+      }
+      table.appendChild(dd);
+    });
+    content.appendChild(table);
+  }
+
+  header.onclick = (e) => {
+    e.stopPropagation();
+    const isOpen = !content.hidden;
+    content.hidden = isOpen;
+    header.setAttribute("aria-expanded", String(!isOpen));
+    header
+      .querySelector(".mageforge-jsonld-chevron")
+      .classList.toggle("mageforge-jsonld-chevron--open", !isOpen);
+  };
+
+  block.appendChild(header);
+  block.appendChild(content);
+  return block;
+}
+
+export default {
+  key: KEY,
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>',
+  label: "Schema.org Viewer",
+  description:
+    "Shows all schema.org microdata (itemscope/itemprop) and RDFa blocks",
+
+  run(context, active) {
+    const auditItem = context.menu?.querySelector(`[data-audit-key="${KEY}"]`);
+    const findingsContainer = auditItem?.querySelector(
+      ".mageforge-audit-findings",
+    );
+
+    if (!active) {
+      if (findingsContainer) {
+        findingsContainer.innerHTML = "";
+        findingsContainer.classList.remove(
+          "mageforge-has-findings",
+          "mageforge-findings-open",
+          "mageforge-jsonld-viewer-open",
+        );
+      }
+      return;
+    }
+
+    // Collect microdata root elements (not nested)
+    const microdataRoots = Array.from(
+      document.querySelectorAll("[itemscope][itemtype]"),
+    ).filter((el) => !el.parentElement?.closest("[itemscope]"));
+
+    const rdfaRoots = collectRdfa();
+    const total = microdataRoots.length + rdfaRoots.length;
+
+    context.setAuditCounterBadge(
+      KEY,
+      String(total),
+      total > 0 ? "success" : "warning",
+    );
+
+    if (!findingsContainer) return;
+
+    findingsContainer.innerHTML = "";
+    findingsContainer.classList.add(
+      "mageforge-has-findings",
+      "mageforge-findings-open",
+      "mageforge-jsonld-viewer-open",
+    );
+
+    if (total === 0) {
+      const empty = document.createElement("p");
+      empty.className = "mageforge-jsonld-empty";
+      empty.textContent = "No schema.org microdata or RDFa found on this page.";
+      findingsContainer.appendChild(empty);
+      return;
+    }
+
+    const summary = document.createElement("div");
+    summary.className = "mageforge-jsonld-summary";
+    summary.innerHTML = `
+      ${microdataRoots.length > 0 ? `<span class="mageforge-jsonld-count">${microdataRoots.length} microdata item${microdataRoots.length !== 1 ? "s" : ""}</span>` : ""}
+      ${rdfaRoots.length > 0 ? `<span class="mageforge-schema-badge mageforge-schema-badge--rdfa">RDFa: ${rdfaRoots.length}</span>` : ""}
+    `;
+    findingsContainer.appendChild(summary);
+
+    microdataRoots.forEach((el) => {
+      const item = collectMicrodata(el);
+      findingsContainer.appendChild(buildBlockDOM(item, "Microdata"));
+    });
+
+    rdfaRoots.forEach(({ type, el }) => {
+      const typeShort = type.replace(/https?:\/\/schema\.org\//i, "");
+      const props = Array.from(el.querySelectorAll("[property]"))
+        .filter(
+          (p) =>
+            !p.parentElement?.closest("[typeof]") ||
+            p.closest("[typeof]") === el,
+        )
+        .map((p) => ({
+          name: p.getAttribute("property") ?? "",
+          value:
+            p.getAttribute("content") ??
+            p.getAttribute("href") ??
+            p.textContent.trim().slice(0, 120),
+          nested: null,
+        }));
+
+      findingsContainer.appendChild(
+        buildBlockDOM(
+          { type: `https://schema.org/${typeShort}`, props },
+          "RDFa",
+        ),
+      );
+    });
+  },
+};

--- a/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
@@ -237,7 +237,15 @@ export default {
     });
 
     rdfaRoots.forEach(({ type, el }) => {
-      const typeShort = type.replace(/https?:\/\/schema\.org\//i, "");
+      // Normalise to a full schema.org URL only when the value is already one;
+      // CURIEs (e.g. "schema:Product") or plain names are passed through as-is
+      // to avoid producing broken URLs like https://schema.org/schema:Product.
+      const normalizedType = /^https?:\/\//i.test(type)
+        ? type
+        : type.includes(":")
+          ? type // CURIE – leave untouched
+          : `https://schema.org/${type}`;
+
       const props = Array.from(el.querySelectorAll("[property]"))
         .filter(
           (p) =>
@@ -254,10 +262,7 @@ export default {
         }));
 
       findingsContainer.appendChild(
-        buildBlockDOM(
-          { type: `https://schema.org/${typeShort}`, props },
-          "RDFa",
-        ),
+        buildBlockDOM({ type: normalizedType, props }, "RDFa"),
       );
     });
   },

--- a/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/schema-org-viewer.js
@@ -82,14 +82,18 @@ function buildBlockDOM(item, badgeLabel) {
   header.type = "button";
   header.className = "mageforge-jsonld-block-header";
   header.setAttribute("aria-expanded", "false");
+  // Static SVG only – dynamic text set via textContent (XSS-safe)
   header.innerHTML = `
     <span class="mageforge-jsonld-block-type">
       <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>
-      ${typeShort || "Unknown Type"}
-      <span class="mageforge-schema-badge">${badgeLabel}</span>
+      <span class="mageforge-schema-type"></span>
+      <span class="mageforge-schema-badge"></span>
     </span>
     <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
   `;
+  header.querySelector(".mageforge-schema-type").textContent =
+    typeShort || "Unknown Type";
+  header.querySelector(".mageforge-schema-badge").textContent = badgeLabel;
 
   const content = document.createElement("div");
   content.className = "mageforge-jsonld-block-content";
@@ -98,7 +102,25 @@ function buildBlockDOM(item, badgeLabel) {
   if (item.type) {
     const typeRow = document.createElement("div");
     typeRow.className = "mageforge-schema-type-row";
-    typeRow.innerHTML = `<span class="mageforge-schema-prop-name">@type</span><a class="mageforge-schema-type-link" href="${item.type}" target="_blank" rel="noopener noreferrer">${item.type}</a>`;
+    const typePropName = document.createElement("span");
+    typePropName.className = "mageforge-schema-prop-name";
+    typePropName.textContent = "@type";
+    typeRow.appendChild(typePropName);
+    // Only linkify http(s) URLs to prevent javascript: injection
+    if (/^https?:\/\//i.test(item.type)) {
+      const typeLink = document.createElement("a");
+      typeLink.className = "mageforge-schema-type-link";
+      typeLink.href = item.type;
+      typeLink.target = "_blank";
+      typeLink.rel = "noopener noreferrer";
+      typeLink.textContent = item.type;
+      typeRow.appendChild(typeLink);
+    } else {
+      const typeText = document.createElement("span");
+      typeText.className = "mageforge-schema-type-link";
+      typeText.textContent = item.type;
+      typeRow.appendChild(typeText);
+    }
     content.appendChild(typeRow);
   }
 

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -353,9 +353,11 @@ function hasField(obj, path) {
   let current = obj;
   for (const part of parts) {
     if (current == null) return false;
-    // If it's an array, check the first element
-    if (Array.isArray(current)) current = current[0];
-    if (current == null) return false;
+    // If it's an array, succeed if any element satisfies the remaining path
+    if (Array.isArray(current)) {
+      const remaining = parts.slice(parts.indexOf(part)).join(".");
+      return current.some((el) => hasField(el, remaining));
+    }
     current = current[part];
   }
   if (current == null) return false;
@@ -667,7 +669,7 @@ export default {
       let parseError = null;
       let issues = [];
       try {
-        parsed = JSON.parse(script.textContent.trim());
+        parsed = JSON.parse((script.textContent ?? "").trim());
         issues = validate(parsed);
         validationErrorCount += issues.filter(
           (i) => i.severity === "error",

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -2,13 +2,411 @@
  * MageForge Toolbar Audit – JSON-LD Viewer
  *
  * Reads all <script type="application/ld+json"> blocks from the current page,
- * parses them, and renders a formatted viewer in the audit findings panel.
- * Invalid JSON blocks are flagged as errors.
+ * parses them, renders a formatted viewer and validates required fields based
+ * on Google Rich Results requirements.
  *
  * Page-level audit: no DOM element highlighting, findings panel shows the data.
  */
 
 const KEY = "seo-json-ld-viewer";
+
+/**
+ * Required/recommended field rules per @type.
+ * Based on Google Rich Results requirements:
+ * https://developers.google.com/search/docs/appearance/structured-data
+ *
+ * Each entry has:
+ *   fields: Array<{ path, severity, message }> — dot-notation field checks
+ *   extra?: (parsed) => Array<{ severity, message }> — custom logic for nested/conditional checks
+ */
+const VALIDATION_RULES = {
+  Product: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "image",
+        severity: "error",
+        message: 'Missing required field "image"',
+      },
+      {
+        path: "offers",
+        severity: "error",
+        message: 'Missing required field "offers"',
+      },
+      {
+        path: "offers.price",
+        severity: "error",
+        message: 'Offer missing "price" (required for rich results)',
+      },
+      {
+        path: "offers.priceCurrency",
+        severity: "error",
+        message: 'Offer missing "priceCurrency"',
+      },
+      {
+        path: "offers.availability",
+        severity: "error",
+        message: 'Offer missing "availability" (required by Google)',
+      },
+      {
+        path: "brand",
+        severity: "warning",
+        message: 'Missing "brand" (required for Google Merchant Center)',
+      },
+      {
+        path: "sku",
+        severity: "warning",
+        message: 'Missing "sku" or "gtin" (recommended for Google Shopping)',
+      },
+      {
+        path: "description",
+        severity: "warning",
+        message: 'Missing recommended field "description"',
+      },
+    ],
+    extra(parsed) {
+      const issues = [];
+      if (parsed.aggregateRating) {
+        if (!hasField(parsed, "aggregateRating.ratingValue")) {
+          issues.push({
+            severity: "error",
+            message: '"aggregateRating" missing required "ratingValue"',
+          });
+        }
+        const hasCount =
+          hasField(parsed, "aggregateRating.reviewCount") ||
+          hasField(parsed, "aggregateRating.ratingCount");
+        if (!hasCount) {
+          issues.push({
+            severity: "error",
+            message: '"aggregateRating" missing "reviewCount" or "ratingCount"',
+          });
+        }
+      }
+      if (parsed.brand && !hasField(parsed, "brand.name")) {
+        issues.push({
+          severity: "error",
+          message: '"brand" object missing "name"',
+        });
+      }
+      return issues;
+    },
+  },
+  BreadcrumbList: {
+    fields: [
+      {
+        path: "itemListElement",
+        severity: "error",
+        message: 'Missing required field "itemListElement"',
+      },
+    ],
+    extra(parsed) {
+      const issues = [];
+      const items = parsed.itemListElement;
+      if (!Array.isArray(items)) return issues;
+      items.forEach((item, i) => {
+        const n = i + 1;
+        if (item.position == null) {
+          issues.push({
+            severity: "error",
+            message: `ListItem[${n}] missing "position"`,
+          });
+        }
+        if (!item.name) {
+          issues.push({
+            severity: "error",
+            message: `ListItem[${n}] missing "name"`,
+          });
+        }
+        if (!item.item) {
+          issues.push({
+            severity: "warning",
+            message: `ListItem[${n}] missing "item" (URL)`,
+          });
+        }
+      });
+      return issues;
+    },
+  },
+  Organization: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "url",
+        severity: "warning",
+        message: 'Missing recommended field "url"',
+      },
+      {
+        path: "logo",
+        severity: "warning",
+        message: 'Missing recommended field "logo"',
+      },
+    ],
+  },
+  WebSite: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "url",
+        severity: "error",
+        message: 'Missing required field "url"',
+      },
+    ],
+  },
+  Article: {
+    fields: [
+      {
+        path: "headline",
+        severity: "error",
+        message: 'Missing required field "headline"',
+      },
+      {
+        path: "author",
+        severity: "error",
+        message: 'Missing required field "author"',
+      },
+      {
+        path: "datePublished",
+        severity: "error",
+        message: 'Missing required field "datePublished"',
+      },
+      {
+        path: "image",
+        severity: "error",
+        message: 'Missing required field "image"',
+      },
+    ],
+  },
+  NewsArticle: {
+    fields: [
+      {
+        path: "headline",
+        severity: "error",
+        message: 'Missing required field "headline"',
+      },
+      {
+        path: "author",
+        severity: "error",
+        message: 'Missing required field "author"',
+      },
+      {
+        path: "datePublished",
+        severity: "error",
+        message: 'Missing required field "datePublished"',
+      },
+      {
+        path: "image",
+        severity: "error",
+        message: 'Missing required field "image"',
+      },
+    ],
+  },
+  FAQPage: {
+    fields: [
+      {
+        path: "mainEntity",
+        severity: "error",
+        message: 'Missing required field "mainEntity"',
+      },
+    ],
+    extra(parsed) {
+      const issues = [];
+      const items = parsed.mainEntity;
+      if (!Array.isArray(items)) return issues;
+      items.forEach((item, i) => {
+        const n = i + 1;
+        if (!item.name) {
+          issues.push({
+            severity: "error",
+            message: `Question[${n}] missing "name" (the question text)`,
+          });
+        }
+        if (!hasField(item, "acceptedAnswer.text")) {
+          issues.push({
+            severity: "error",
+            message: `Question[${n}] missing "acceptedAnswer.text"`,
+          });
+        }
+      });
+      return issues;
+    },
+  },
+  LocalBusiness: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "address",
+        severity: "error",
+        message: 'Missing required field "address"',
+      },
+      {
+        path: "telephone",
+        severity: "warning",
+        message: 'Missing recommended field "telephone"',
+      },
+    ],
+  },
+  Event: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "startDate",
+        severity: "error",
+        message: 'Missing required field "startDate"',
+      },
+      {
+        path: "location",
+        severity: "error",
+        message: 'Missing required field "location"',
+      },
+    ],
+  },
+  Recipe: {
+    fields: [
+      {
+        path: "name",
+        severity: "error",
+        message: 'Missing required field "name"',
+      },
+      {
+        path: "image",
+        severity: "error",
+        message: 'Missing required field "image"',
+      },
+      {
+        path: "author",
+        severity: "error",
+        message: 'Missing required field "author"',
+      },
+    ],
+  },
+  Order: {
+    fields: [
+      {
+        path: "orderNumber",
+        severity: "error",
+        message: 'Missing required field "orderNumber"',
+      },
+      {
+        path: "orderStatus",
+        severity: "error",
+        message: 'Missing required field "orderStatus"',
+      },
+      {
+        path: "merchant",
+        severity: "error",
+        message: 'Missing required field "merchant" (seller/Organization)',
+      },
+      {
+        path: "orderedItem",
+        severity: "error",
+        message: 'Missing required field "orderedItem"',
+      },
+      {
+        path: "priceCurrency",
+        severity: "warning",
+        message: 'Missing recommended field "priceCurrency"',
+      },
+      {
+        path: "price",
+        severity: "warning",
+        message: 'Missing recommended field "price" (order total)',
+      },
+      {
+        path: "customer",
+        severity: "warning",
+        message: 'Missing recommended field "customer"',
+      },
+    ],
+  },
+};
+
+/**
+ * Resolve a dot-notation path on an object, traversing arrays if needed.
+ *
+ * @param {object} obj
+ * @param {string} path
+ * @returns {boolean} true if value exists and is non-empty
+ */
+function hasField(obj, path) {
+  const parts = path.split(".");
+  let current = obj;
+  for (const part of parts) {
+    if (current == null) return false;
+    // If it's an array, check the first element
+    if (Array.isArray(current)) current = current[0];
+    if (current == null) return false;
+    current = current[part];
+  }
+  if (current == null) return false;
+  if (typeof current === "string") return current.trim().length > 0;
+  return true;
+}
+
+/**
+ * Validate a parsed JSON-LD object against known rules.
+ *
+ * @param {object} parsed
+ * @returns {Array<{severity: string, message: string}>}
+ */
+function validate(parsed) {
+  if (!parsed || typeof parsed !== "object") return [];
+
+  const issues = [];
+
+  if (!parsed["@context"]) {
+    issues.push({
+      severity: "error",
+      message: 'Missing "@context" (should be "https://schema.org")',
+    });
+  }
+
+  const type = parsed["@type"];
+  if (!type) {
+    issues.push({ severity: "warning", message: 'Missing "@type"' });
+    return issues;
+  }
+
+  const config = VALIDATION_RULES[type];
+  if (!config) return issues;
+
+  (config.fields ?? []).forEach(({ path, severity, message }) => {
+    if (!hasField(parsed, path)) {
+      issues.push({ severity, message });
+    }
+  });
+
+  if (typeof config.extra === "function") {
+    issues.push(...config.extra(parsed));
+  }
+
+  return issues;
+}
+
+const ICON_ERROR =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>';
+const ICON_WARN =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>';
 
 export default {
   key: KEY,
@@ -55,20 +453,37 @@ export default {
       return;
     }
 
-    let errorCount = 0;
+    let parseErrorCount = 0;
+    let validationErrorCount = 0;
+    let validationWarningCount = 0;
+
     const blocks = scripts.map((script, index) => {
       let parsed = null;
       let parseError = null;
+      let issues = [];
       try {
         parsed = JSON.parse(script.textContent.trim());
+        issues = validate(parsed);
+        validationErrorCount += issues.filter(
+          (i) => i.severity === "error",
+        ).length;
+        validationWarningCount += issues.filter(
+          (i) => i.severity === "warning",
+        ).length;
       } catch (e) {
         parseError = e.message;
-        errorCount++;
+        parseErrorCount++;
       }
-      return { index, parsed, parseError, raw: script.textContent.trim() };
+      return { index, parsed, parseError, issues };
     });
 
-    const severity = errorCount > 0 ? "error" : "success";
+    const totalIssues = parseErrorCount + validationErrorCount;
+    const severity =
+      parseErrorCount > 0 || validationErrorCount > 0
+        ? "error"
+        : validationWarningCount > 0
+          ? "warning"
+          : "success";
     context.setAuditCounterBadge(KEY, String(scripts.length), severity);
 
     if (!findingsContainer) return;
@@ -84,11 +499,16 @@ export default {
     summary.className = "mageforge-jsonld-summary";
     summary.innerHTML = `
       <span class="mageforge-jsonld-count">${scripts.length} block${scripts.length !== 1 ? "s" : ""} found</span>
-      ${errorCount > 0 ? `<span class="mageforge-jsonld-errors">${errorCount} invalid</span>` : ""}
+      ${parseErrorCount > 0 ? `<span class="mageforge-jsonld-errors">${parseErrorCount} invalid JSON</span>` : ""}
+      ${validationErrorCount > 0 ? `<span class="mageforge-jsonld-errors">${validationErrorCount} missing required</span>` : ""}
+      ${validationWarningCount > 0 ? `<span class="mageforge-jsonld-warnings">${validationWarningCount} warnings</span>` : ""}
     `;
     findingsContainer.appendChild(summary);
 
-    blocks.forEach(({ index, parsed, parseError }) => {
+    blocks.forEach(({ index, parsed, parseError, issues }) => {
+      const hasErrors = issues.some((i) => i.severity === "error");
+      const hasWarnings = issues.some((i) => i.severity === "warning");
+
       const type =
         parsed?.["@type"] ??
         (Array.isArray(parsed)
@@ -107,7 +527,18 @@ export default {
       const block = document.createElement("div");
       block.className =
         "mageforge-jsonld-block" +
-        (parseError ? " mageforge-jsonld-block--error" : "");
+        (parseError || hasErrors ? " mageforge-jsonld-block--error" : "") +
+        (!parseError && !hasErrors && hasWarnings
+          ? " mageforge-jsonld-block--warning"
+          : "");
+
+      // Validation badge for header
+      const validationBadge =
+        parseError || hasErrors
+          ? `<span class="mageforge-jsonld-val-badge mageforge-jsonld-val-badge--error">${ICON_ERROR} ${parseError ? "Invalid JSON" : `${issues.filter((i) => i.severity === "error").length} error${issues.filter((i) => i.severity === "error").length !== 1 ? "s" : ""}`}</span>`
+          : hasWarnings
+            ? `<span class="mageforge-jsonld-val-badge mageforge-jsonld-val-badge--warning">${ICON_WARN} ${issues.filter((i) => i.severity === "warning").length} warning${issues.filter((i) => i.severity === "warning").length !== 1 ? "s" : ""}</span>`
+            : "";
 
       const header = document.createElement("button");
       header.type = "button";
@@ -115,12 +546,9 @@ export default {
       header.setAttribute("aria-expanded", "false");
       header.innerHTML = `
         <span class="mageforge-jsonld-block-type">
-          ${
-            parseError
-              ? '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>'
-              : '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>'
-          }
+          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
           ${parseError ? `Block ${index + 1} — Invalid JSON` : typeLabel}
+          ${validationBadge}
         </span>
         <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
       `;
@@ -135,6 +563,19 @@ export default {
         errorMsg.textContent = `Parse error: ${parseError}`;
         content.appendChild(errorMsg);
       } else {
+        // Validation issues list
+        if (issues.length > 0) {
+          const issueList = document.createElement("ul");
+          issueList.className = "mageforge-jsonld-issues";
+          issues.forEach(({ severity, message }) => {
+            const li = document.createElement("li");
+            li.className = `mageforge-jsonld-issue mageforge-jsonld-issue--${severity}`;
+            li.innerHTML = `${severity === "error" ? ICON_ERROR : ICON_WARN} ${message}`;
+            issueList.appendChild(li);
+          });
+          content.appendChild(issueList);
+        }
+
         const pre = document.createElement("pre");
         pre.className = "mageforge-jsonld-pre";
         const code = document.createElement("code");

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -351,26 +351,20 @@ const VALIDATION_RULES = {
 function hasField(obj, path) {
   const parts = path.split(".");
   let current = obj;
-  for (const part of parts) {
+  for (let i = 0; i < parts.length; i++) {
     if (current == null) return false;
     // If it's an array, succeed if any element satisfies the remaining path
     if (Array.isArray(current)) {
-      const remaining = parts.slice(parts.indexOf(part)).join(".");
+      const remaining = parts.slice(i).join(".");
       return current.some((el) => hasField(el, remaining));
     }
-    current = current[part];
+    current = current[parts[i]];
   }
   if (current == null) return false;
   if (typeof current === "string") return current.trim().length > 0;
   return true;
 }
 
-/**
- * Validate a parsed JSON-LD object against known rules.
- *
- * @param {object} parsed
- * @returns {Array<{severity: string, message: string}>}
- */
 /**
  * Validate a single JSON-LD node object against known rules.
  *
@@ -429,6 +423,7 @@ function validate(parsed) {
   if (Array.isArray(parsed["@graph"])) {
     const outerContext = parsed["@context"];
     return parsed["@graph"].flatMap((node) => {
+      if (!node || typeof node !== "object" || Array.isArray(node)) return [];
       // Inherit outer @context when the node omits it
       const effective =
         outerContext && !node["@context"]
@@ -678,7 +673,7 @@ export default {
           (i) => i.severity === "warning",
         ).length;
       } catch (e) {
-        parseError = e.message;
+        parseError = String(e?.message ?? e);
         parseErrorCount++;
       }
       return { index, parsed, parseError, issues };

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -1,0 +1,184 @@
+/**
+ * MageForge Toolbar Audit – JSON-LD Viewer
+ *
+ * Reads all <script type="application/ld+json"> blocks from the current page,
+ * parses them, and renders a formatted viewer in the audit findings panel.
+ * Invalid JSON blocks are flagged as errors.
+ *
+ * Page-level audit: no DOM element highlighting, findings panel shows the data.
+ */
+
+const KEY = "seo-json-ld-viewer";
+
+export default {
+  key: KEY,
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M7 4a2 2 0 0 0 -2 2v3a2 3 0 0 1 -2 3a2 3 0 0 1 2 3v3a2 2 0 0 0 2 2"></path><path d="M17 4a2 2 0 0 1 2 2v3a2 3 0 0 1 2 3a2 3 0 0 1 -2 3v3a2 2 0 0 1 -2 2"></path><path d="M11 12h1l1 3"></path><circle cx="11" cy="9" r=".5" fill="currentColor"></circle></svg>',
+  label: "JSON-LD Viewer",
+  description: "Shows all structured data (JSON-LD) blocks found on this page",
+
+  run(context, active) {
+    const auditItem = context.menu?.querySelector(`[data-audit-key="${KEY}"]`);
+    const findingsContainer = auditItem?.querySelector(
+      ".mageforge-audit-findings",
+    );
+
+    if (!active) {
+      if (findingsContainer) {
+        findingsContainer.innerHTML = "";
+        findingsContainer.classList.remove(
+          "mageforge-has-findings",
+          "mageforge-findings-open",
+          "mageforge-jsonld-viewer-open",
+        );
+      }
+      return;
+    }
+
+    const scripts = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    );
+
+    if (scripts.length === 0) {
+      context.setAuditCounterBadge(KEY, "0", "warning");
+      if (findingsContainer) {
+        findingsContainer.innerHTML = "";
+        const empty = document.createElement("p");
+        empty.className = "mageforge-jsonld-empty";
+        empty.textContent = "No JSON-LD blocks found on this page.";
+        findingsContainer.appendChild(empty);
+        findingsContainer.classList.add(
+          "mageforge-has-findings",
+          "mageforge-findings-open",
+          "mageforge-jsonld-viewer-open",
+        );
+      }
+      return;
+    }
+
+    let errorCount = 0;
+    const blocks = scripts.map((script, index) => {
+      let parsed = null;
+      let parseError = null;
+      try {
+        parsed = JSON.parse(script.textContent.trim());
+      } catch (e) {
+        parseError = e.message;
+        errorCount++;
+      }
+      return { index, parsed, parseError, raw: script.textContent.trim() };
+    });
+
+    const severity = errorCount > 0 ? "error" : "success";
+    context.setAuditCounterBadge(KEY, String(scripts.length), severity);
+
+    if (!findingsContainer) return;
+
+    findingsContainer.innerHTML = "";
+    findingsContainer.classList.add(
+      "mageforge-has-findings",
+      "mageforge-findings-open",
+      "mageforge-jsonld-viewer-open",
+    );
+
+    const summary = document.createElement("div");
+    summary.className = "mageforge-jsonld-summary";
+    summary.innerHTML = `
+      <span class="mageforge-jsonld-count">${scripts.length} block${scripts.length !== 1 ? "s" : ""} found</span>
+      ${errorCount > 0 ? `<span class="mageforge-jsonld-errors">${errorCount} invalid</span>` : ""}
+    `;
+    findingsContainer.appendChild(summary);
+
+    blocks.forEach(({ index, parsed, parseError }) => {
+      const type =
+        parsed?.["@type"] ??
+        (Array.isArray(parsed)
+          ? parsed
+              .map((b) => b?.["@type"])
+              .filter(Boolean)
+              .join(", ") || "Array"
+          : "Unknown");
+
+      const name = typeof parsed?.name === "string" ? parsed.name.trim() : null;
+      const nameLabel = name
+        ? " — " + (name.length > 75 ? name.slice(0, 74) + "…" : name)
+        : "";
+      const typeLabel = type + nameLabel;
+
+      const block = document.createElement("div");
+      block.className =
+        "mageforge-jsonld-block" +
+        (parseError ? " mageforge-jsonld-block--error" : "");
+
+      const header = document.createElement("button");
+      header.type = "button";
+      header.className = "mageforge-jsonld-block-header";
+      header.setAttribute("aria-expanded", "false");
+      header.innerHTML = `
+        <span class="mageforge-jsonld-block-type">
+          ${
+            parseError
+              ? '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>'
+              : '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>'
+          }
+          ${parseError ? `Block ${index + 1} — Invalid JSON` : typeLabel}
+        </span>
+        <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+      `;
+
+      const content = document.createElement("div");
+      content.className = "mageforge-jsonld-block-content";
+      content.hidden = true;
+
+      if (parseError) {
+        const errorMsg = document.createElement("p");
+        errorMsg.className = "mageforge-jsonld-parse-error";
+        errorMsg.textContent = `Parse error: ${parseError}`;
+        content.appendChild(errorMsg);
+      } else {
+        const pre = document.createElement("pre");
+        pre.className = "mageforge-jsonld-pre";
+        const code = document.createElement("code");
+        code.textContent = JSON.stringify(parsed, null, 2);
+        pre.appendChild(code);
+        content.appendChild(pre);
+
+        const copyBtn = document.createElement("button");
+        copyBtn.type = "button";
+        copyBtn.className = "mageforge-jsonld-copy-btn";
+        copyBtn.textContent = "Copy";
+        copyBtn.onclick = (e) => {
+          e.stopPropagation();
+          navigator.clipboard
+            .writeText(JSON.stringify(parsed, null, 2))
+            .then(() => {
+              copyBtn.textContent = "Copied!";
+              setTimeout(() => {
+                copyBtn.textContent = "Copy";
+              }, 1500);
+            })
+            .catch(() => {
+              copyBtn.textContent = "Failed";
+              setTimeout(() => {
+                copyBtn.textContent = "Copy";
+              }, 1500);
+            });
+        };
+        content.appendChild(copyBtn);
+      }
+
+      header.onclick = (e) => {
+        e.stopPropagation();
+        const isOpen = content.hidden === false;
+        content.hidden = isOpen;
+        header.setAttribute("aria-expanded", String(!isOpen));
+        header
+          .querySelector(".mageforge-jsonld-chevron")
+          .classList.toggle("mageforge-jsonld-chevron--open", !isOpen);
+      };
+
+      block.appendChild(header);
+      block.appendChild(content);
+      findingsContainer.appendChild(block);
+    });
+  },
+};

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -369,19 +369,25 @@ function hasField(obj, path) {
  * @param {object} parsed
  * @returns {Array<{severity: string, message: string}>}
  */
-function validate(parsed) {
-  if (!parsed || typeof parsed !== "object") return [];
+/**
+ * Validate a single JSON-LD node object against known rules.
+ *
+ * @param {object} node
+ * @returns {Array<{severity: string, message: string}>}
+ */
+function validateNode(node) {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return [];
 
   const issues = [];
 
-  if (!parsed["@context"]) {
+  if (!node["@context"]) {
     issues.push({
       severity: "error",
       message: 'Missing "@context" (should be "https://schema.org")',
     });
   }
 
-  const type = parsed["@type"];
+  const type = node["@type"];
   if (!type) {
     issues.push({ severity: "warning", message: 'Missing "@type"' });
     return issues;
@@ -391,16 +397,46 @@ function validate(parsed) {
   if (!config) return issues;
 
   (config.fields ?? []).forEach(({ path, severity, message }) => {
-    if (!hasField(parsed, path)) {
+    if (!hasField(node, path)) {
       issues.push({ severity, message });
     }
   });
 
   if (typeof config.extra === "function") {
-    issues.push(...config.extra(parsed));
+    issues.push(...config.extra(node));
   }
 
   return issues;
+}
+
+/**
+ * Validate a parsed JSON-LD value, handling top-level arrays and @graph wrappers.
+ *
+ * @param {unknown} parsed
+ * @returns {Array<{severity: string, message: string}>}
+ */
+function validate(parsed) {
+  if (!parsed || typeof parsed !== "object") return [];
+
+  // Top-level array: validate each node individually
+  if (Array.isArray(parsed)) {
+    return parsed.flatMap((node) => validateNode(node));
+  }
+
+  // @graph wrapper: the outer object carries @context; propagate it to each node
+  if (Array.isArray(parsed["@graph"])) {
+    const outerContext = parsed["@context"];
+    return parsed["@graph"].flatMap((node) => {
+      // Inherit outer @context when the node omits it
+      const effective =
+        outerContext && !node["@context"]
+          ? { "@context": outerContext, ...node }
+          : node;
+      return validateNode(effective);
+    });
+  }
+
+  return validateNode(parsed);
 }
 
 const ICON_ERROR =
@@ -646,7 +682,6 @@ export default {
       return { index, parsed, parseError, issues };
     });
 
-    const totalIssues = parseErrorCount + validationErrorCount;
     const severity =
       parseErrorCount > 0 || validationErrorCount > 0
         ? "error"

--- a/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
+++ b/src/view/frontend/web/js/toolbar/audits/seo-json-ld-viewer.js
@@ -408,6 +408,175 @@ const ICON_ERROR =
 const ICON_WARN =
   '<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>';
 
+/** Extract a display label from a parsed JSON-LD object. */
+function buildTypeLabel(parsed) {
+  const type =
+    parsed?.["@type"] ??
+    (Array.isArray(parsed)
+      ? parsed
+          .map((b) => b?.["@type"])
+          .filter(Boolean)
+          .join(", ") || "Array"
+      : "Unknown");
+  const name = typeof parsed?.name === "string" ? parsed.name.trim() : null;
+  const nameLabel = name
+    ? " \u2014 " + (name.length > 75 ? name.slice(0, 74) + "\u2026" : name)
+    : "";
+  return type + nameLabel;
+}
+
+/** Build the collapsible block header button (XSS-safe). */
+function buildBlockHeader(titleText, issues, parseError) {
+  const hasErrors = issues.some((i) => i.severity === "error");
+  const hasWarnings = issues.some((i) => i.severity === "warning");
+
+  const header = document.createElement("button");
+  header.type = "button";
+  header.className = "mageforge-jsonld-block-header";
+  header.setAttribute("aria-expanded", "false");
+  header.innerHTML = `
+    <span class="mageforge-jsonld-block-type">
+      <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+      <span class="mageforge-jsonld-block-title"></span>
+      <span class="mageforge-jsonld-badge-slot"></span>
+    </span>
+    <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+  `;
+  header.querySelector(".mageforge-jsonld-block-title").textContent = titleText;
+
+  if (parseError || hasErrors || hasWarnings) {
+    const errCount = issues.filter((i) => i.severity === "error").length;
+    const warnCount = issues.filter((i) => i.severity === "warning").length;
+    const isError = parseError || hasErrors;
+    const badgeEl = document.createElement("span");
+    badgeEl.className =
+      "mageforge-jsonld-val-badge " +
+      (isError
+        ? "mageforge-jsonld-val-badge--error"
+        : "mageforge-jsonld-val-badge--warning");
+    badgeEl.innerHTML = isError ? ICON_ERROR : ICON_WARN;
+    badgeEl.appendChild(
+      document.createTextNode(
+        isError
+          ? ` ${parseError ? "Invalid JSON" : `${errCount} error${errCount !== 1 ? "s" : ""}`}`
+          : ` ${warnCount} warning${warnCount !== 1 ? "s" : ""}`,
+      ),
+    );
+    header.querySelector(".mageforge-jsonld-badge-slot").appendChild(badgeEl);
+  }
+
+  return header;
+}
+
+/** Build the issues list shown above the JSON code. */
+function buildIssueList(issues) {
+  const list = document.createElement("ul");
+  list.className = "mageforge-jsonld-issues";
+  issues.forEach(({ severity, message }) => {
+    const li = document.createElement("li");
+    li.className = `mageforge-jsonld-issue mageforge-jsonld-issue--${severity}`;
+    li.innerHTML = severity === "error" ? ICON_ERROR : ICON_WARN;
+    li.appendChild(document.createTextNode(` ${message}`));
+    list.appendChild(li);
+  });
+  return list;
+}
+
+/** Build the copy button for a parsed JSON-LD block. */
+function buildCopyButton(parsed) {
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.className = "mageforge-jsonld-copy-btn";
+  copyBtn.textContent = "Copy";
+  copyBtn.onclick = (e) => {
+    e.stopPropagation();
+    if (!navigator.clipboard?.writeText) {
+      copyBtn.textContent = "Not available";
+      setTimeout(() => {
+        copyBtn.textContent = "Copy";
+      }, 1500);
+      return;
+    }
+    navigator.clipboard
+      .writeText(JSON.stringify(parsed, null, 2))
+      .then(() => {
+        copyBtn.textContent = "Copied!";
+        setTimeout(() => {
+          copyBtn.textContent = "Copy";
+        }, 1500);
+      })
+      .catch(() => {
+        copyBtn.textContent = "Failed";
+        setTimeout(() => {
+          copyBtn.textContent = "Copy";
+        }, 1500);
+      });
+  };
+  return copyBtn;
+}
+
+/** Build the expandable content area for one JSON-LD block. */
+function buildBlockContent(parsed, parseError, issues) {
+  const content = document.createElement("div");
+  content.className = "mageforge-jsonld-block-content";
+  content.hidden = true;
+
+  if (parseError) {
+    const errorMsg = document.createElement("p");
+    errorMsg.className = "mageforge-jsonld-parse-error";
+    errorMsg.textContent = `Parse error: ${parseError}`;
+    content.appendChild(errorMsg);
+    return content;
+  }
+
+  if (issues.length > 0) content.appendChild(buildIssueList(issues));
+
+  const pre = document.createElement("pre");
+  pre.className = "mageforge-jsonld-pre";
+  const code = document.createElement("code");
+  code.textContent = JSON.stringify(parsed, null, 2);
+  pre.appendChild(code);
+  content.appendChild(pre);
+  content.appendChild(buildCopyButton(parsed));
+
+  return content;
+}
+
+/** Build a complete collapsible block for one JSON-LD script. */
+function buildBlock({ index, parsed, parseError, issues }) {
+  const hasErrors = issues.some((i) => i.severity === "error");
+  const hasWarnings = issues.some((i) => i.severity === "warning");
+
+  const titleText = parseError
+    ? `Block ${index + 1} \u2014 Invalid JSON`
+    : buildTypeLabel(parsed);
+
+  const block = document.createElement("div");
+  block.className =
+    "mageforge-jsonld-block" +
+    (parseError || hasErrors ? " mageforge-jsonld-block--error" : "") +
+    (!parseError && !hasErrors && hasWarnings
+      ? " mageforge-jsonld-block--warning"
+      : "");
+
+  const header = buildBlockHeader(titleText, issues, parseError);
+  const content = buildBlockContent(parsed, parseError, issues);
+
+  header.onclick = (e) => {
+    e.stopPropagation();
+    const isOpen = !content.hidden;
+    content.hidden = isOpen;
+    header.setAttribute("aria-expanded", String(!isOpen));
+    header
+      .querySelector(".mageforge-jsonld-chevron")
+      .classList.toggle("mageforge-jsonld-chevron--open", !isOpen);
+  };
+
+  block.appendChild(header);
+  block.appendChild(content);
+  return block;
+}
+
 export default {
   key: KEY,
   icon: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M7 4a2 2 0 0 0 -2 2v3a2 3 0 0 1 -2 3a2 3 0 0 1 2 3v3a2 2 0 0 0 2 2"></path><path d="M17 4a2 2 0 0 1 2 2v3a2 3 0 0 1 2 3a2 3 0 0 1 -2 3v3a2 2 0 0 1 -2 2"></path><path d="M11 12h1l1 3"></path><circle cx="11" cy="9" r=".5" fill="currentColor"></circle></svg>',
@@ -505,121 +674,8 @@ export default {
     `;
     findingsContainer.appendChild(summary);
 
-    blocks.forEach(({ index, parsed, parseError, issues }) => {
-      const hasErrors = issues.some((i) => i.severity === "error");
-      const hasWarnings = issues.some((i) => i.severity === "warning");
-
-      const type =
-        parsed?.["@type"] ??
-        (Array.isArray(parsed)
-          ? parsed
-              .map((b) => b?.["@type"])
-              .filter(Boolean)
-              .join(", ") || "Array"
-          : "Unknown");
-
-      const name = typeof parsed?.name === "string" ? parsed.name.trim() : null;
-      const nameLabel = name
-        ? " — " + (name.length > 75 ? name.slice(0, 74) + "…" : name)
-        : "";
-      const typeLabel = type + nameLabel;
-
-      const block = document.createElement("div");
-      block.className =
-        "mageforge-jsonld-block" +
-        (parseError || hasErrors ? " mageforge-jsonld-block--error" : "") +
-        (!parseError && !hasErrors && hasWarnings
-          ? " mageforge-jsonld-block--warning"
-          : "");
-
-      // Validation badge for header
-      const validationBadge =
-        parseError || hasErrors
-          ? `<span class="mageforge-jsonld-val-badge mageforge-jsonld-val-badge--error">${ICON_ERROR} ${parseError ? "Invalid JSON" : `${issues.filter((i) => i.severity === "error").length} error${issues.filter((i) => i.severity === "error").length !== 1 ? "s" : ""}`}</span>`
-          : hasWarnings
-            ? `<span class="mageforge-jsonld-val-badge mageforge-jsonld-val-badge--warning">${ICON_WARN} ${issues.filter((i) => i.severity === "warning").length} warning${issues.filter((i) => i.severity === "warning").length !== 1 ? "s" : ""}</span>`
-            : "";
-
-      const header = document.createElement("button");
-      header.type = "button";
-      header.className = "mageforge-jsonld-block-header";
-      header.setAttribute("aria-expanded", "false");
-      header.innerHTML = `
-        <span class="mageforge-jsonld-block-type">
-          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
-          ${parseError ? `Block ${index + 1} — Invalid JSON` : typeLabel}
-          ${validationBadge}
-        </span>
-        <svg class="mageforge-jsonld-chevron" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
-      `;
-
-      const content = document.createElement("div");
-      content.className = "mageforge-jsonld-block-content";
-      content.hidden = true;
-
-      if (parseError) {
-        const errorMsg = document.createElement("p");
-        errorMsg.className = "mageforge-jsonld-parse-error";
-        errorMsg.textContent = `Parse error: ${parseError}`;
-        content.appendChild(errorMsg);
-      } else {
-        // Validation issues list
-        if (issues.length > 0) {
-          const issueList = document.createElement("ul");
-          issueList.className = "mageforge-jsonld-issues";
-          issues.forEach(({ severity, message }) => {
-            const li = document.createElement("li");
-            li.className = `mageforge-jsonld-issue mageforge-jsonld-issue--${severity}`;
-            li.innerHTML = `${severity === "error" ? ICON_ERROR : ICON_WARN} ${message}`;
-            issueList.appendChild(li);
-          });
-          content.appendChild(issueList);
-        }
-
-        const pre = document.createElement("pre");
-        pre.className = "mageforge-jsonld-pre";
-        const code = document.createElement("code");
-        code.textContent = JSON.stringify(parsed, null, 2);
-        pre.appendChild(code);
-        content.appendChild(pre);
-
-        const copyBtn = document.createElement("button");
-        copyBtn.type = "button";
-        copyBtn.className = "mageforge-jsonld-copy-btn";
-        copyBtn.textContent = "Copy";
-        copyBtn.onclick = (e) => {
-          e.stopPropagation();
-          navigator.clipboard
-            .writeText(JSON.stringify(parsed, null, 2))
-            .then(() => {
-              copyBtn.textContent = "Copied!";
-              setTimeout(() => {
-                copyBtn.textContent = "Copy";
-              }, 1500);
-            })
-            .catch(() => {
-              copyBtn.textContent = "Failed";
-              setTimeout(() => {
-                copyBtn.textContent = "Copy";
-              }, 1500);
-            });
-        };
-        content.appendChild(copyBtn);
-      }
-
-      header.onclick = (e) => {
-        e.stopPropagation();
-        const isOpen = content.hidden === false;
-        content.hidden = isOpen;
-        header.setAttribute("aria-expanded", String(!isOpen));
-        header
-          .querySelector(".mageforge-jsonld-chevron")
-          .classList.toggle("mageforge-jsonld-chevron--open", !isOpen);
-      };
-
-      block.appendChild(header);
-      block.appendChild(content);
-      findingsContainer.appendChild(block);
+    blocks.forEach((blockData) => {
+      findingsContainer.appendChild(buildBlock(blockData));
     });
   },
 };

--- a/src/view/frontend/web/js/toolbar/ui/build.js
+++ b/src/view/frontend/web/js/toolbar/ui/build.js
@@ -239,7 +239,7 @@ export const buildMethods = {
     btn.dataset.tab = key;
     btn.innerHTML = `
       <span class="mageforge-tab-icon" aria-hidden="true">${icon}</span>
-      <span class="mageforge-tab-label">${label.split(" ")[0]}</span>
+      <span class="mageforge-tab-label">${label}</span>
       <span class="mageforge-tab-badges" data-tab-badges-for="${key}">
         <span class="mageforge-tab-badge mageforge-tab-badge--errors" data-type="errors"></span>
         <span class="mageforge-tab-badge mageforge-tab-badge--warnings" data-type="warnings"></span>

--- a/src/view/frontend/web/js/toolbar/ui/constants.js
+++ b/src/view/frontend/web/js/toolbar/ui/constants.js
@@ -13,6 +13,8 @@ export const GROUP_ICONS = {
   performance:
     '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>',
   seo: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>',
+  "structured-data":
+    '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 4a2 2 0 0 0-2 2v3a2 3 0 0 1-2 3a2 3 0 0 1 2 3v3a2 2 0 0 0 2 2"></path><path d="M17 4a2 2 0 0 1 2 2v3a2 3 0 0 1 2 3a2 3 0 0 1-2 3v3a2 2 0 0 1-2 2"></path></svg>',
 };
 
 export const GAUGE_ARC_LENGTH = 157.08; // π × r(50) — half-arc stroke length


### PR DESCRIPTION
This pull request introduces a comprehensive "Structured Data" audit group to the MageForge Toolbar, with new viewers for JSON-LD and Schema.org microdata/RDFa, along with supporting UI and style changes. These enhancements make it easier to inspect and debug structured data on web pages directly from the findings panel.

**Structured Data Auditing:**

- Added a new "Structured Data" audit group, including:
  - A JSON-LD viewer that lists all `<script type="application/ld+json">` blocks, parses and displays them, flags errors, and allows copying valid JSON. [[1]](diffhunk://#diff-36cba740aecf5341aaf3ae91d356d10b0997a99e3cb8f55b061c15e9392a7b8cR1-R184) [[2]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L82-R88)
  - A Schema.org microdata and RDFa viewer that scans the DOM for `itemscope`/`itemtype` and `typeof`/`property` attributes, presenting a structured, interactive tree view of found data. [[1]](diffhunk://#diff-dd300d7f4c56f96d87b9d765efefbcee23ea677a4b1d5b828eadff09fac64621R1-R242) [[2]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L82-R88)
- The missing JSON-LD audit was moved from the "SEO" group to "Structured Data" for better organization. [[1]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L41-R43) [[2]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L82-R88)

**UI and Styling:**

- Introduced new CSS styles for the JSON-LD viewer, Schema.org viewer, and structured data badges, ensuring consistent and clear presentation in the findings panel. [[1]](diffhunk://#diff-0c5023d9e856193d2b2c5dc1cf6a9627c1488a3ef7cff9ee9ef8eeba7184651eR1-R218) [[2]](diffhunk://#diff-7e2df700a3be7c0c5e89ccf0d3b843887c240e613c16a66551e8030f326bc024R17)
- Added a new CSS variable for structured data group color, used in the toolbar.
- Updated the toolbar tab label rendering to show the full label instead of just the first word, improving clarity for new audit groups.

**Summary of most important changes:**

**Structured Data Auditing**
- Added `seo-json-ld-viewer.js` and `schema-org-viewer.js` audits for JSON-LD and microdata/RDFa, with interactive viewers in the findings panel. [[1]](diffhunk://#diff-36cba740aecf5341aaf3ae91d356d10b0997a99e3cb8f55b061c15e9392a7b8cR1-R184) [[2]](diffhunk://#diff-dd300d7f4c56f96d87b9d765efefbcee23ea677a4b1d5b828eadff09fac64621R1-R242)
- Registered the new audits and the "Structured Data" audit group in the audit index, and moved the missing JSON-LD audit into this group. [[1]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L41-R43) [[2]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811R55) [[3]](diffhunk://#diff-f958dc1b098072192b60ec3ce4e0f078f8663fc59854d9cef944801a94fce811L82-R88)

**UI and Styling**
- Added new CSS module `toolbar/_jsonld-viewer.css` and imported it into the main toolbar stylesheet for viewer styling. [[1]](diffhunk://#diff-0c5023d9e856193d2b2c5dc1cf6a9627c1488a3ef7cff9ee9ef8eeba7184651eR1-R218) [[2]](diffhunk://#diff-7e2df700a3be7c0c5e89ccf0d3b843887c240e613c16a66551e8030f326bc024R17)
- Introduced a CSS variable for structured data group color.
- Updated tab label rendering to display the full label for better group identification.