### PR TITLE
refactor: simplify condition checks in various files

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,9 +6,11 @@
 
     <arg name="extensions" value="php,phtml"/>
 
-    <rule ref="Magento2">
-        <!-- Mago formats multi-line conditions PSR-12 style (newline after the
-             opening parenthesis); this PSR-2-era sniff would flag that. -->
-        <exclude name="PSR2.ControlStructures.ControlStructureSpacing"/>
-    </rule>
+    <!-- Full Magento2 standard, no exclusions: external package checkers run the
+         plain standard against the published package, so any local exclusion would
+         hide findings that still fail there. Multi-line conditions conflict with
+         Mago's PSR-12 wrapping (newline after the opening parenthesis, flagged by
+         PSR2.ControlStructures.ControlStructureSpacing) — keep conditions on one
+         line by extracting sub-expressions into variables instead. -->
+    <rule ref="Magento2"/>
 </ruleset>

--- a/src/Console/Command/System/CheckCommand.php
+++ b/src/Console/Command/System/CheckCommand.php
@@ -163,12 +163,8 @@ class CheckCommand extends AbstractCommand
 
             /** @var array<int, array<string, mixed>> $nodes */
             foreach ($nodes as $node) {
-                if (
-                    isset($node['lts'])
-                    && $node['lts'] !== false
-                    && isset($node['version'])
-                    && is_string($node['version'])
-                ) {
+                $isLtsRelease = isset($node['lts']) && $node['lts'] !== false;
+                if ($isLtsRelease && isset($node['version']) && is_string($node['version'])) {
                     return trim($node['version'], 'v');
                 }
             }

--- a/src/Service/Hyva/ModuleScanner.php
+++ b/src/Service/Hyva/ModuleScanner.php
@@ -125,11 +125,11 @@ class ModuleScanner
     {
         // Check if this IS a Hyvä compatibility package
         $packageName = $composerData['name'] ?? '';
-        if (
+        $isCompatPackage =
             is_string($packageName)
             && str_starts_with($packageName, 'hyva-themes/')
-            && str_contains($packageName, '-compat')
-        ) {
+            && str_contains($packageName, '-compat');
+        if ($isCompatPackage) {
             return true;
         }
 

--- a/src/Service/ThemeBuilder/HyvaThemes/Builder.php
+++ b/src/Service/ThemeBuilder/HyvaThemes/Builder.php
@@ -68,12 +68,8 @@ class Builder implements BuilderInterface
         if ($this->fileDriver->isExists($themePath . '/composer.json')) {
             $composerContent = $this->fileDriver->fileGetContents($themePath . '/composer.json');
             $composerJson = json_decode($composerContent, true);
-            if (
-                is_array($composerJson)
-                && isset($composerJson['name'])
-                && is_string($composerJson['name'])
-                && str_contains($composerJson['name'], 'hyva')
-            ) {
+            $packageName = is_array($composerJson) ? $composerJson['name'] ?? null : null;
+            if (is_string($packageName) && str_contains($packageName, 'hyva')) {
                 return true;
             }
         }

--- a/src/Service/ThemeBuilder/TailwindCSS/Builder.php
+++ b/src/Service/ThemeBuilder/TailwindCSS/Builder.php
@@ -68,12 +68,8 @@ class Builder implements BuilderInterface
         if ($this->fileDriver->isExists($themePath . '/composer.json')) {
             $composerContent = $this->fileDriver->fileGetContents($themePath . '/composer.json');
             $composerJson = json_decode($composerContent, true);
-            if (
-                \is_array($composerJson)
-                && isset($composerJson['name'])
-                && \is_string($composerJson['name'])
-                && !str_contains($composerJson['name'], 'hyva')
-            ) {
+            $packageName = \is_array($composerJson) ? $composerJson['name'] ?? null : null;
+            if (\is_string($packageName) && !str_contains($packageName, 'hyva')) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request introduces several code simplifications and refactorings to improve readability and maintainability, as well as an update to the PHP CodeSniffer configuration for stricter code style enforcement. The main changes include extracting boolean expressions into variables for clarity, updating the code style rules to match external package checkers, and simplifying logic for composer package detection.

**Code Simplification and Refactoring:**

* Extracted boolean logic into variables for clarity in methods such as `getLatestLtsNodeVersion`, `isHyvaCompatibilityPackage`, and theme builder detection methods. This makes the code easier to read and debug. [[1]](diffhunk://#diff-d9a630c11ecf253a97b9a8eb4c8b28d012763e0d7287c4e81e6be41314c33bd9L166-R167) [[2]](diffhunk://#diff-71b32f4e0b8e619b798a58d3077e49c655cea115d1d57440d53942f30dc38d88L128-R132) [[3]](diffhunk://#diff-527643adf1559dda9002569ca24f700e5e6fb4e82987f6f09ea804f6f6f134abL71-R72) [[4]](diffhunk://#diff-c0b49291fcbbc551e9315ad1eb5b737a9b236bb4462c24e6bf6ebc343680a7d2L71-R72)

**Code Style and Standards:**

* Updated `phpcs.xml.dist` to enforce the full Magento2 coding standard without local exclusions. This ensures that the codebase adheres to the same standards as external package checkers, preventing hidden issues. The comment now recommends extracting sub-expressions into variables to avoid multi-line condition conflicts.