### PR TITLE
feat: add dependency updater command

### DIFF
--- a/.github/workflows/magento-compatibility.yml
+++ b/.github/workflows/magento-compatibility.yml
@@ -104,6 +104,7 @@ jobs:
           bin/magento mageforge:theme:inspector --help
           bin/magento mageforge:hyva:compatibility:check --help
           bin/magento mageforge:hyva:tokens --help
+          bin/magento mageforge:dependencies:update --help
 
           echo "Verify command aliases work:"
           bin/magento m:s:v --help
@@ -119,6 +120,7 @@ jobs:
           bin/magento frontend:clean --help
           bin/magento hyva:check --help
           bin/magento hyva:tokens --help
+          bin/magento dependencies:update --help
 
       - name: Test Summary
         run: |

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -129,7 +129,7 @@ bin/magento mageforge:theme:inspector status
 
 ### `mageforge:dependencies:update`
 
-Updates the Node.js dependencies (npm packages) of one or more themes. Works with all themes that ship their own `package.json`, e.g. Hyvä and TailwindCSS themes (`web/tailwind/package.json`).
+Updates the Node.js dependencies (npm packages) of one or more themes. Works with all themes that ship their own `package.json`, e.g. Hyvä and TailwindCSS themes (`web/tailwind/package.json`). For standard Magento themes (e.g. `Magento/luma`) the Node.js setup in the Magento root is updated instead, since that is what builds their assets.
 
 ```bash
 bin/magento mageforge:dependencies:update <theme-code> [<theme-code> ...]
@@ -153,7 +153,9 @@ bin/magento mageforge:dependencies:update Vendor/theme --latest
 - By default runs a safe `npm update`: packages are only updated within the semver ranges defined in `package.json` (`package.json` itself stays untouched).
 - With `--latest`, outdated packages are updated to their latest released versions, grouped by dependency type (`dependencies`, `devDependencies`, ...).
 - Installs `node_modules` first if missing, so the report is meaningful.
-- Themes installed in `vendor/` (managed by Composer) and themes without their own `package.json` (e.g. standard Magento themes built from the Magento root Node.js setup) are skipped with an explanation.
+- Themes installed in `vendor/` (managed by Composer) are skipped with an explanation.
+- Standard Magento themes (Luma-based, no own `package.json`) fall back to the `package.json` in the Magento root (copied from `package.json.sample`), which powers their Grunt build. The root setup is shared, so it is updated at most once per run; if the Magento root has no `package.json`, the theme is skipped with a setup hint. Note that with `--latest` this major-bumps Grunt tooling used by **all** standard themes.
+- Other themes without their own `package.json` are skipped.
 - After a successful update, a hint reminds you to rebuild the affected themes with `mageforge:theme:build`.
 
 ---

--- a/docs/commands_reference.md
+++ b/docs/commands_reference.md
@@ -4,17 +4,18 @@ Complete reference of all CLI commands provided by the MageForge module.
 
 ## Quick Overview
 
-| Group      | Command                              | Description                                         | Aliases          |
-| ---------- | ------------------------------------ | --------------------------------------------------- | ---------------- |
-| **Theme**  | `mageforge:theme:list`               | List all available Magento themes                   | `frontend:list`  |
-| **Theme**  | `mageforge:theme:build`              | Build selected themes (CSS/TailwindCSS)             | `frontend:build` |
-| **Theme**  | `mageforge:theme:watch`              | Watch theme files and auto-rebuild                  | `frontend:watch` |
-| **Theme**  | `mageforge:theme:clean`              | Clean static files and cache directories            | `frontend:clean` |
-| **Theme**  | `mageforge:theme:inspector`          | Manage Frontend Inspector (enable/disable/status)   | —                |
-| **Hyvä**   | `mageforge:hyva:tokens`              | Generate Hyvä design tokens                         | `hyva:tokens`    |
-| **Hyvä**   | `mageforge:hyva:compatibility:check` | Check modules for Hyvä compatibility issues         | `hyva:check`     |
-| **System** | `mageforge:system:version`           | Show current and latest module version              | `system:version` |
-| **System** | `mageforge:system:check`             | Display system information (PHP, Node.js, DB, etc.) | `system:check`   |
+| Group            | Command                              | Description                                         | Aliases               |
+| ---------------- | ------------------------------------ | --------------------------------------------------- | --------------------- |
+| **Theme**        | `mageforge:theme:list`               | List all available Magento themes                   | `frontend:list`       |
+| **Theme**        | `mageforge:theme:build`              | Build selected themes (CSS/TailwindCSS)             | `frontend:build`      |
+| **Theme**        | `mageforge:theme:watch`              | Watch theme files and auto-rebuild                  | `frontend:watch`      |
+| **Theme**        | `mageforge:theme:clean`              | Clean static files and cache directories            | `frontend:clean`      |
+| **Theme**        | `mageforge:theme:inspector`          | Manage Frontend Inspector (enable/disable/status)   | —                     |
+| **Dependencies** | `mageforge:dependencies:update`      | Update the Node.js dependencies of themes           | `dependencies:update` |
+| **Hyvä**         | `mageforge:hyva:tokens`              | Generate Hyvä design tokens                         | `hyva:tokens`         |
+| **Hyvä**         | `mageforge:hyva:compatibility:check` | Check modules for Hyvä compatibility issues         | `hyva:check`          |
+| **System**       | `mageforge:system:version`           | Show current and latest module version              | `system:version`      |
+| **System**       | `mageforge:system:check`             | Display system information (PHP, Node.js, DB, etc.) | `system:check`        |
 
 ---
 
@@ -124,6 +125,39 @@ bin/magento mageforge:theme:inspector status
 
 ---
 
+## Dependencies Commands
+
+### `mageforge:dependencies:update`
+
+Updates the Node.js dependencies (npm packages) of one or more themes. Works with all themes that ship their own `package.json`, e.g. Hyvä and TailwindCSS themes (`web/tailwind/package.json`).
+
+```bash
+bin/magento mageforge:dependencies:update <theme-code> [<theme-code> ...]
+bin/magento mageforge:dependencies:update Vendor/theme
+bin/magento mageforge:dependencies:update Vendor/theme --dry-run
+bin/magento mageforge:dependencies:update Vendor/theme --latest
+```
+
+**Arguments:**
+
+- `themeCodes` — One or more theme codes in format `Vendor/theme`. Accepts wildcards like `Vendor/*`. If omitted, an interactive prompt lets you select themes.
+
+**Options:**
+
+- `--dry-run` — Only show the outdated packages without changing anything.
+- `-l, --latest` — Update packages beyond their semver ranges to the latest available versions. This rewrites `package.json` and may pull in breaking changes.
+
+**Behavior:**
+
+- Shows a table of all outdated packages (current, wanted, latest version and dependency type) per theme.
+- By default runs a safe `npm update`: packages are only updated within the semver ranges defined in `package.json` (`package.json` itself stays untouched).
+- With `--latest`, outdated packages are updated to their latest released versions, grouped by dependency type (`dependencies`, `devDependencies`, ...).
+- Installs `node_modules` first if missing, so the report is meaningful.
+- Themes installed in `vendor/` (managed by Composer) and themes without their own `package.json` (e.g. standard Magento themes built from the Magento root Node.js setup) are skipped with an explanation.
+- After a successful update, a hint reminds you to rebuild the affected themes with `mageforge:theme:build`.
+
+---
+
 ## Hyvä Commands
 
 ### `mageforge:hyva:tokens`
@@ -210,6 +244,7 @@ mageforge:theme:build         → Build theme assets
 mageforge:theme:watch         → Watch & auto-rebuild
 mageforge:theme:clean         → Clean static files
 mageforge:theme:inspector     → Manage inspector tool
+mageforge:dependencies:update → Update theme Node.js dependencies
 mageforge:hyva:tokens         → Generate Hyvä design tokens
 mageforge:hyva:compatibility:check → Check Hyvä compatibility
 mageforge:system:version      → Show module version

--- a/src/Console/Command/Dependencies/UpdateCommand.php
+++ b/src/Console/Command/Dependencies/UpdateCommand.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Console\Command\Dependencies;
+
+use Laravel\Prompts\MultiSearchPrompt;
+use Magento\Framework\Console\Cli;
+use OpenForgeProject\MageForge\Console\Command\AbstractCommand;
+use OpenForgeProject\MageForge\Model\ThemeList;
+use OpenForgeProject\MageForge\Model\ThemePath;
+use OpenForgeProject\MageForge\Service\DependencyUpdater;
+use OpenForgeProject\MageForge\Service\ThemeSuggester;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command for updating the Node.js dependencies of themes
+ */
+class UpdateCommand extends AbstractCommand
+{
+    /**
+     * @param DependencyUpdater $dependencyUpdater
+     * @param ThemePath $themePath
+     * @param ThemeList $themeList
+     * @param ThemeSuggester $themeSuggester
+     */
+    public function __construct(
+        private readonly DependencyUpdater $dependencyUpdater,
+        private readonly ThemePath $themePath,
+        private readonly ThemeList $themeList,
+        private readonly ThemeSuggester $themeSuggester,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configure command.
+     *
+     * @return void
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName($this->getCommandName('dependencies', 'update'))
+            ->setDescription('Update the Node.js dependencies of one or more themes')
+            ->addArgument(
+                'themeCodes',
+                InputArgument::IS_ARRAY,
+                'Theme codes to update (format: Vendor/theme, Vendor, ...)',
+            )
+            ->addOption(
+                'latest',
+                'l',
+                InputOption::VALUE_NONE,
+                'Update packages beyond their semver ranges to the latest versions (updates package.json)',
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show outdated packages without changing anything')
+            ->setAliases(['dependencies:update']);
+    }
+
+    /**
+     * Execute command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function executeCommand(InputInterface $input, OutputInterface $output): int
+    {
+        $latest = (bool) $input->getOption('latest');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if ($dryRun) {
+            $this->io->note('DRY RUN MODE: No dependencies will be changed');
+        }
+
+        $themeCodes = $this->resolveThemeCodes($input, $output);
+
+        if ($themeCodes === null) {
+            return Cli::RETURN_SUCCESS;
+        }
+
+        $startTime = microtime(true);
+
+        [$updatedThemes, $failedThemes] = $this->processThemes($themeCodes, $latest, $dryRun, $output);
+
+        $this->displaySummary($updatedThemes, $failedThemes, $dryRun, microtime(true) - $startTime);
+
+        if (empty($updatedThemes) && !empty($failedThemes)) {
+            return Cli::RETURN_FAILURE;
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Resolve which themes to update based on input
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return array<string>|null Array of theme codes or null to exit
+     */
+    private function resolveThemeCodes(InputInterface $input, OutputInterface $output): ?array
+    {
+        /** @var array<string> $themeCodes */
+        $themeCodes = $input->getArgument('themeCodes');
+
+        if (!empty($themeCodes)) {
+            $themeCodes = $this->resolveVendorThemes($themeCodes, $this->themeList);
+
+            // If wildcards matched nothing and no other explicit themes remain
+            if (empty($themeCodes)) {
+                return null;
+            }
+
+            return $themeCodes;
+        }
+
+        return $this->selectThemesInteractively($output);
+    }
+
+    /**
+     * Select themes interactively
+     *
+     * @param OutputInterface $output
+     * @return array<string>|null
+     */
+    private function selectThemesInteractively(OutputInterface $output): ?array
+    {
+        $themes = $this->themeList->getAllThemes();
+        $options = array_values(array_map(static fn($theme) => $theme->getCode(), $themes));
+
+        if (!$this->isInteractiveTerminal($output)) {
+            $this->displayAvailableThemes($themes);
+            return null;
+        }
+
+        return $this->promptForThemes($options, $themes);
+    }
+
+    /**
+     * Display available themes for non-interactive environments
+     *
+     * @param \Magento\Theme\Model\Theme[] $themes
+     * @return void
+     */
+    private function displayAvailableThemes(array $themes): void
+    {
+        $this->io->warning('No theme specified. Available themes:');
+
+        if (empty($themes)) {
+            $this->io->info('No themes found.');
+            return;
+        }
+
+        foreach ($themes as $theme) {
+            $this->io->writeln(sprintf('  - <fg=cyan>%s</> (%s)', $theme->getCode(), $theme->getThemeTitle()));
+        }
+
+        $this->io->newLine();
+        $this->io->info('Usage: bin/magento mageforge:dependencies:update <theme-code> [<theme-code>...]');
+        $this->io->info('Example: bin/magento mageforge:dependencies:update Vendor/theme');
+    }
+
+    /**
+     * Prompt user to select themes
+     *
+     * @param string[] $options
+     * @param \Magento\Theme\Model\Theme[] $themes
+     * @return string[]|null
+     */
+    private function promptForThemes(array $options, array $themes): ?array
+    {
+        $this->setPromptEnvironment();
+
+        $themeCodesPrompt = new MultiSearchPrompt(
+            label: 'Select themes to update dependencies for',
+            options: static fn(string $value) => empty($value)
+                ? $options
+                : array_values(array_filter($options, static fn($option) => stripos($option, $value) !== false)),
+            placeholder: 'Type to search theme...',
+            hint: 'Type to search, arrow keys to navigate, Space to toggle, Enter to confirm',
+            required: false,
+        );
+
+        try {
+            $themeCodes = $themeCodesPrompt->prompt();
+            \Laravel\Prompts\Prompt::terminal()->restoreTty();
+            $this->resetPromptEnvironment();
+
+            if (empty($themeCodes)) {
+                $this->io->info('No themes selected.');
+                return null;
+            }
+
+            /** @var array<string> $themeCodes */
+            return $themeCodes;
+        } catch (\Exception $e) {
+            $this->resetPromptEnvironment();
+            $this->io->error('Interactive mode failed: ' . $e->getMessage());
+            $this->displayAvailableThemes($themes);
+            return null;
+        }
+    }
+
+    /**
+     * Process the dependency update for all selected themes
+     *
+     * @param array<string> $themeCodes
+     * @param bool $latest
+     * @param bool $dryRun
+     * @param OutputInterface $output
+     * @return array{array<string>, array<string>} [updatedThemes, failedThemes]
+     */
+    private function processThemes(array $themeCodes, bool $latest, bool $dryRun, OutputInterface $output): array
+    {
+        $isVerbose = $this->isVerbose($output);
+        $totalThemes = count($themeCodes);
+        $updatedThemes = [];
+        $failedThemes = [];
+
+        foreach ($themeCodes as $index => $themeCode) {
+            $currentTheme = (int) $index + 1;
+
+            $validatedTheme = $this->validateTheme($themeCode, $failedThemes, $output);
+
+            if ($validatedTheme === null) {
+                continue;
+            }
+
+            if ($totalThemes > 1) {
+                $this->io->section(sprintf(
+                    'Updating dependencies %d of %d: %s',
+                    $currentTheme,
+                    $totalThemes,
+                    $validatedTheme,
+                ));
+            } else {
+                $this->io->section(sprintf('Updating dependencies for theme: %s', $validatedTheme));
+            }
+
+            $themePath = (string) $this->themePath->getPath($validatedTheme);
+
+            $success = $this->dependencyUpdater->updateThemeDependencies(
+                $validatedTheme,
+                $themePath,
+                $this->io,
+                $isVerbose,
+                $latest,
+                $dryRun,
+            );
+
+            if ($success) {
+                $updatedThemes[] = $validatedTheme;
+            } else {
+                $failedThemes[] = $validatedTheme;
+            }
+        }
+
+        return [$updatedThemes, $failedThemes];
+    }
+
+    /**
+     * Validate theme exists, offering suggestions for invalid codes
+     *
+     * @param string $themeCode
+     * @param array<string> $failedThemes
+     * @param OutputInterface $output
+     * @return string|null Theme code if valid or corrected, null if invalid
+     */
+    private function validateTheme(string $themeCode, array &$failedThemes, OutputInterface $output): ?string
+    {
+        $themePath = $this->themePath->getPath($themeCode);
+
+        if ($themePath === null) {
+            // Try to suggest similar themes
+            $correctedTheme = $this->handleInvalidThemeWithSuggestions($themeCode, $this->themeSuggester, $output);
+
+            // If no theme was selected, mark as failed
+            if ($correctedTheme === null) {
+                $failedThemes[] = $themeCode;
+                return null;
+            }
+
+            // Double-check the corrected theme exists
+            if ($this->themePath->getPath($correctedTheme) === null) {
+                $this->io->error(sprintf("Theme '%s' not found.", $correctedTheme));
+                $failedThemes[] = $themeCode;
+                return null;
+            }
+
+            $this->io->info("Using theme: $correctedTheme");
+            return $correctedTheme;
+        }
+
+        return $themeCode;
+    }
+
+    /**
+     * Display summary of the update operation
+     *
+     * @param array<string> $updatedThemes
+     * @param array<string> $failedThemes
+     * @param bool $dryRun
+     * @param float $duration
+     * @return void
+     */
+    private function displaySummary(array $updatedThemes, array $failedThemes, bool $dryRun, float $duration): void
+    {
+        $this->io->newLine();
+
+        if (!empty($updatedThemes)) {
+            $action = $dryRun ? 'Checked' : 'Updated';
+            $this->io->success(sprintf(
+                '%s dependencies for %d theme(s) in %.2f seconds: %s',
+                $action,
+                count($updatedThemes),
+                $duration,
+                implode(', ', $updatedThemes),
+            ));
+
+            if (!$dryRun) {
+                $this->io->note(sprintf('Rebuild the updated theme(s) to apply the changes: '
+                . 'bin/magento mageforge:theme:build %s', implode(' ', $updatedThemes)));
+            }
+        } else {
+            $this->io->info('No theme dependencies were updated.');
+        }
+
+        if (!empty($failedThemes)) {
+            $this->io->warning(sprintf(
+                'Failed to process %d theme(s): %s',
+                count($failedThemes),
+                implode(', ', $failedThemes),
+            ));
+        }
+    }
+}

--- a/src/Console/Command/Dependencies/UpdateCommand.php
+++ b/src/Console/Command/Dependencies/UpdateCommand.php
@@ -10,6 +10,7 @@ use OpenForgeProject\MageForge\Console\Command\AbstractCommand;
 use OpenForgeProject\MageForge\Model\ThemeList;
 use OpenForgeProject\MageForge\Model\ThemePath;
 use OpenForgeProject\MageForge\Service\DependencyUpdater;
+use OpenForgeProject\MageForge\Service\DependencyUpdateResult;
 use OpenForgeProject\MageForge\Service\ThemeSuggester;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -85,9 +86,9 @@ class UpdateCommand extends AbstractCommand
 
         $startTime = microtime(true);
 
-        [$updatedThemes, $failedThemes] = $this->processThemes($themeCodes, $latest, $dryRun, $output);
+        [$updatedThemes, $skippedThemes, $failedThemes] = $this->processThemes($themeCodes, $latest, $dryRun, $output);
 
-        $this->displaySummary($updatedThemes, $failedThemes, $dryRun, microtime(true) - $startTime);
+        $this->displaySummary($updatedThemes, $skippedThemes, $failedThemes, $dryRun, microtime(true) - $startTime);
 
         if (empty($updatedThemes) && !empty($failedThemes)) {
             return Cli::RETURN_FAILURE;
@@ -213,13 +214,14 @@ class UpdateCommand extends AbstractCommand
      * @param bool $latest
      * @param bool $dryRun
      * @param OutputInterface $output
-     * @return array{array<string>, array<string>} [updatedThemes, failedThemes]
+     * @return array{array<string>, array<string>, array<string>} [updatedThemes, skippedThemes, failedThemes]
      */
     private function processThemes(array $themeCodes, bool $latest, bool $dryRun, OutputInterface $output): array
     {
         $isVerbose = $this->isVerbose($output);
         $totalThemes = count($themeCodes);
         $updatedThemes = [];
+        $skippedThemes = [];
         $failedThemes = [];
 
         foreach ($themeCodes as $index => $themeCode) {
@@ -244,7 +246,7 @@ class UpdateCommand extends AbstractCommand
 
             $themePath = (string) $this->themePath->getPath($validatedTheme);
 
-            $success = $this->dependencyUpdater->updateThemeDependencies(
+            $result = $this->dependencyUpdater->updateThemeDependencies(
                 $validatedTheme,
                 $themePath,
                 $this->io,
@@ -253,14 +255,14 @@ class UpdateCommand extends AbstractCommand
                 $dryRun,
             );
 
-            if ($success) {
-                $updatedThemes[] = $validatedTheme;
-            } else {
-                $failedThemes[] = $validatedTheme;
-            }
+            match ($result) {
+                DependencyUpdateResult::Updated => $updatedThemes[] = $validatedTheme,
+                DependencyUpdateResult::Skipped => $skippedThemes[] = $validatedTheme,
+                DependencyUpdateResult::Failed => $failedThemes[] = $validatedTheme,
+            };
         }
 
-        return [$updatedThemes, $failedThemes];
+        return [$updatedThemes, $skippedThemes, $failedThemes];
     }
 
     /**
@@ -303,13 +305,19 @@ class UpdateCommand extends AbstractCommand
      * Display summary of the update operation
      *
      * @param array<string> $updatedThemes
+     * @param array<string> $skippedThemes
      * @param array<string> $failedThemes
      * @param bool $dryRun
      * @param float $duration
      * @return void
      */
-    private function displaySummary(array $updatedThemes, array $failedThemes, bool $dryRun, float $duration): void
-    {
+    private function displaySummary(
+        array $updatedThemes,
+        array $skippedThemes,
+        array $failedThemes,
+        bool $dryRun,
+        float $duration,
+    ): void {
         $this->io->newLine();
 
         if (!empty($updatedThemes)) {
@@ -328,6 +336,10 @@ class UpdateCommand extends AbstractCommand
             }
         } else {
             $this->io->info('No theme dependencies were updated.');
+        }
+
+        if (!empty($skippedThemes)) {
+            $this->io->note(sprintf('Skipped %d theme(s): %s', count($skippedThemes), implode(', ', $skippedThemes)));
         }
 
         if (!empty($failedThemes)) {

--- a/src/Service/DependencyUpdateResult.php
+++ b/src/Service/DependencyUpdateResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+/**
+ * Outcome of a single theme's dependency update attempt
+ */
+enum DependencyUpdateResult
+{
+    /**
+     * Dependencies were processed successfully
+     */
+    case Updated;
+
+    /**
+     * The theme was intentionally skipped (e.g. vendor-managed or no own package.json)
+     */
+    case Skipped;
+
+    /**
+     * Dependencies could not be processed
+     */
+    case Failed;
+}

--- a/src/Service/DependencyUpdater.php
+++ b/src/Service/DependencyUpdater.php
@@ -49,7 +49,7 @@ class DependencyUpdater
      * @param bool $isVerbose
      * @param bool $latest Update beyond semver ranges to the latest versions
      * @param bool $dryRun Only report outdated packages without changing anything
-     * @return bool
+     * @return DependencyUpdateResult
      */
     public function updateThemeDependencies(
         string $themeCode,
@@ -58,7 +58,7 @@ class DependencyUpdater
         bool $isVerbose,
         bool $latest,
         bool $dryRun,
-    ): bool {
+    ): DependencyUpdateResult {
         $themePath = rtrim($themePath, '/');
 
         if ($this->isVendorTheme($themePath)) {
@@ -66,7 +66,7 @@ class DependencyUpdater
                 "Theme '%s' is installed in the vendor directory and is managed by Composer. Skipping.",
                 $themeCode,
             ));
-            return false;
+            return DependencyUpdateResult::Skipped;
         }
 
         $packageDirectories = $this->getPackageDirectories($themePath);
@@ -76,7 +76,7 @@ class DependencyUpdater
                 . 'root Node.js setup, which is not updated by this command.',
                 $themeCode,
             ));
-            return false;
+            return DependencyUpdateResult::Skipped;
         }
 
         $result = true;
@@ -86,7 +86,7 @@ class DependencyUpdater
             }
         }
 
-        return $result;
+        return $result ? DependencyUpdateResult::Updated : DependencyUpdateResult::Failed;
     }
 
     /**
@@ -149,6 +149,14 @@ class DependencyUpdater
         }
 
         $outdated = $this->nodePackageManager->getOutdatedPackages($directory);
+        if ($outdated === null) {
+            $io->warning(sprintf(
+                'Could not check for outdated packages in %s. Make sure Node.js and npm are available.',
+                $directory,
+            ));
+            return false;
+        }
+
         if (empty($outdated)) {
             $io->writeln(sprintf('  <fg=green>✓</> All packages in %s are up to date.', $directory));
             return true;
@@ -228,6 +236,11 @@ class DependencyUpdater
     private function reportRemainingOutdatedPackages(string $directory, bool $latest, SymfonyStyle $io): void
     {
         $remaining = $this->nodePackageManager->getOutdatedPackages($directory);
+
+        if ($remaining === null) {
+            $io->warning(sprintf('Could not verify the update result for %s.', $directory));
+            return;
+        }
 
         if (empty($remaining)) {
             $io->writeln(sprintf('  <fg=green>✓</> All packages in %s are now up to date.', $directory));

--- a/src/Service/DependencyUpdater.php
+++ b/src/Service/DependencyUpdater.php
@@ -181,14 +181,18 @@ class DependencyUpdater
     }
 
     /**
-     * Check if the theme is installed in the vendor directory (managed by Composer)
+     * Check if the theme is installed in the Composer vendor directory
+     *
+     * Anchored to the vendor directory in the Magento root so that themes whose
+     * vendor name is literally "vendor" (e.g. app/design/frontend/vendor/theme)
+     * are not mistaken for Composer-managed themes.
      *
      * @param string $themePath
      * @return bool
      */
     public function isVendorTheme(string $themePath): bool
     {
-        return str_contains($themePath, '/vendor/');
+        return str_starts_with($themePath, rtrim($this->directoryList->getRoot(), '/') . '/vendor/');
     }
 
     /**

--- a/src/Service/DependencyUpdater.php
+++ b/src/Service/DependencyUpdater.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Service;
+
+use Magento\Framework\Filesystem\Driver\File;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Service for updating the Node.js dependencies of a theme
+ *
+ * Locates the theme-owned package.json files (e.g. web/tailwind for Hyva and
+ * TailwindCSS themes), reports outdated packages and updates them either within
+ * their semver ranges (default) or to the latest available versions (--latest).
+ */
+class DependencyUpdater
+{
+    private const TAILWIND_DIR = 'web/tailwind';
+    private const PACKAGE_JSON = 'package.json';
+    private const NODE_MODULES = 'node_modules';
+
+    /**
+     * Pattern for valid npm package names (validate-npm-package-name rules)
+     */
+    private const PACKAGE_NAME_PATTERN = '/^(?:@[a-z0-9\-~][a-z0-9\-._~]*\/)?[a-z0-9\-~][a-z0-9\-._~]*$/';
+
+    /**
+     * Pattern for valid npm package versions
+     */
+    private const VERSION_PATTERN = '/^[0-9a-zA-Z.+\-]+$/';
+
+    /**
+     * @param File $fileDriver
+     * @param NodePackageManager $nodePackageManager
+     */
+    public function __construct(
+        private readonly File $fileDriver,
+        private readonly NodePackageManager $nodePackageManager,
+    ) {
+    }
+
+    /**
+     * Update the Node.js dependencies of a theme
+     *
+     * @param string $themeCode
+     * @param string $themePath
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @param bool $latest Update beyond semver ranges to the latest versions
+     * @param bool $dryRun Only report outdated packages without changing anything
+     * @return bool
+     */
+    public function updateThemeDependencies(
+        string $themeCode,
+        string $themePath,
+        SymfonyStyle $io,
+        bool $isVerbose,
+        bool $latest,
+        bool $dryRun,
+    ): bool {
+        $themePath = rtrim($themePath, '/');
+
+        if ($this->isVendorTheme($themePath)) {
+            $io->warning(sprintf(
+                "Theme '%s' is installed in the vendor directory and is managed by Composer. Skipping.",
+                $themeCode,
+            ));
+            return false;
+        }
+
+        $packageDirectories = $this->getPackageDirectories($themePath);
+        if (empty($packageDirectories)) {
+            $io->warning(sprintf(
+                "Theme '%s' has no own package.json. Standard Magento themes are built from the Magento "
+                . 'root Node.js setup, which is not updated by this command.',
+                $themeCode,
+            ));
+            return false;
+        }
+
+        $result = true;
+        foreach ($packageDirectories as $directory) {
+            if (!$this->processPackageDirectory($directory, $io, $isVerbose, $latest, $dryRun)) {
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the theme-owned directories containing a package.json
+     *
+     * @param string $themePath
+     * @return array<string>
+     */
+    public function getPackageDirectories(string $themePath): array
+    {
+        $themePath = rtrim($themePath, '/');
+        $candidates = [$themePath . '/' . self::TAILWIND_DIR, $themePath];
+
+        $directories = [];
+        foreach ($candidates as $candidate) {
+            if ($this->fileDriver->isExists($candidate . '/' . self::PACKAGE_JSON)) {
+                $directories[] = $candidate;
+            }
+        }
+
+        return $directories;
+    }
+
+    /**
+     * Check if the theme is installed in the vendor directory (managed by Composer)
+     *
+     * @param string $themePath
+     * @return bool
+     */
+    public function isVendorTheme(string $themePath): bool
+    {
+        return str_contains($themePath, '/vendor/');
+    }
+
+    /**
+     * Report and update the outdated packages of a single package directory
+     *
+     * @param string $directory
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @param bool $latest
+     * @param bool $dryRun
+     * @return bool
+     */
+    private function processPackageDirectory(
+        string $directory,
+        SymfonyStyle $io,
+        bool $isVerbose,
+        bool $latest,
+        bool $dryRun,
+    ): bool {
+        // Install first so the "current" column of the outdated report is meaningful
+        if (!$dryRun && !$this->fileDriver->isDirectory($directory . '/' . self::NODE_MODULES)) {
+            if ($isVerbose) {
+                $io->text('node_modules missing. Installing dependencies first...');
+            }
+            if (!$this->nodePackageManager->installNodeModules($directory, $io, $isVerbose)) {
+                return false;
+            }
+        }
+
+        $outdated = $this->nodePackageManager->getOutdatedPackages($directory);
+        if (empty($outdated)) {
+            $io->writeln(sprintf('  <fg=green>✓</> All packages in %s are up to date.', $directory));
+            return true;
+        }
+
+        $this->renderOutdatedTable($directory, $outdated, $io);
+
+        if ($dryRun) {
+            $target = $latest ? 'the latest versions' : 'the versions within the semver ranges of package.json';
+            $io->note(sprintf(
+                'Dry run: would update %d package(s) in %s to %s.',
+                count($outdated),
+                $directory,
+                $target,
+            ));
+            return true;
+        }
+
+        $success = $latest
+            ? $this->updateToLatest($directory, $outdated, $io, $isVerbose)
+            : $this->nodePackageManager->updatePackages($directory, $io, $isVerbose);
+
+        if (!$success) {
+            return false;
+        }
+
+        $this->reportRemainingOutdatedPackages($directory, $latest, $io);
+
+        return true;
+    }
+
+    /**
+     * Update all outdated packages to their latest versions, grouped by dependency type
+     *
+     * @param string $directory
+     * @param array<int,array{name:string,current:string,wanted:string,latest:string,type:string}> $outdated
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @return bool
+     */
+    private function updateToLatest(string $directory, array $outdated, SymfonyStyle $io, bool $isVerbose): bool
+    {
+        $packagesByType = [];
+        foreach ($outdated as $package) {
+            if ($package['latest'] === '-' || $package['latest'] === $package['current']) {
+                continue;
+            }
+            if (!$this->isSafePackageSpec($package['name'], $package['latest'])) {
+                $io->warning(sprintf(
+                    'Skipping package with unexpected name or version: %s@%s',
+                    $package['name'],
+                    $package['latest'],
+                ));
+                continue;
+            }
+            $packagesByType[$package['type']][$package['name']] = $package['latest'];
+        }
+
+        $result = true;
+        foreach ($packagesByType as $type => $packages) {
+            if (!$this->nodePackageManager->installPackageVersions($directory, $type, $packages, $io, $isVerbose)) {
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Report packages that are still outdated after the update
+     *
+     * @param string $directory
+     * @param bool $latest
+     * @param SymfonyStyle $io
+     * @return void
+     */
+    private function reportRemainingOutdatedPackages(string $directory, bool $latest, SymfonyStyle $io): void
+    {
+        $remaining = $this->nodePackageManager->getOutdatedPackages($directory);
+
+        if (empty($remaining)) {
+            $io->writeln(sprintf('  <fg=green>✓</> All packages in %s are now up to date.', $directory));
+            return;
+        }
+
+        if ($latest) {
+            $io->warning(sprintf(
+                '%d package(s) in %s are still outdated. Check the npm output for details.',
+                count($remaining),
+                $directory,
+            ));
+            return;
+        }
+
+        $io->note(sprintf(
+            '%d package(s) in %s have newer versions outside their semver range. '
+            . 'Run again with --latest to update them (may contain breaking changes).',
+            count($remaining),
+            $directory,
+        ));
+    }
+
+    /**
+     * Render the outdated packages as a table
+     *
+     * @param string $directory
+     * @param array<int,array{name:string,current:string,wanted:string,latest:string,type:string}> $outdated
+     * @param SymfonyStyle $io
+     * @return void
+     */
+    private function renderOutdatedTable(string $directory, array $outdated, SymfonyStyle $io): void
+    {
+        $io->writeln(sprintf('  Outdated packages in <fg=cyan>%s</>:', $directory));
+
+        $rows = [];
+        foreach ($outdated as $package) {
+            $rows[] = [
+                sprintf('<fg=cyan>%s</>', $package['name']),
+                $package['current'],
+                $package['wanted'],
+                $this->formatLatestVersion($package['current'], $package['latest']),
+                $package['type'],
+            ];
+        }
+
+        $io->table(['Package', 'Current', 'Wanted', 'Latest', 'Type'], $rows);
+    }
+
+    /**
+     * Highlight the latest version in yellow when it is a major update
+     *
+     * @param string $current
+     * @param string $latest
+     * @return string
+     */
+    private function formatLatestVersion(string $current, string $latest): string
+    {
+        $currentMajor = explode('.', $current)[0];
+        $latestMajor = explode('.', $latest)[0];
+
+        if ($currentMajor !== $latestMajor) {
+            return sprintf('<fg=yellow>%s</>', $latest);
+        }
+
+        return sprintf('<fg=green>%s</>', $latest);
+    }
+
+    /**
+     * Validate that a package name and version are safe to pass to npm
+     *
+     * @param string $name
+     * @param string $version
+     * @return bool
+     */
+    private function isSafePackageSpec(string $name, string $version): bool
+    {
+        return preg_match(self::PACKAGE_NAME_PATTERN, $name) === 1 && preg_match(self::VERSION_PATTERN, $version) === 1;
+    }
+}

--- a/src/Service/DependencyUpdater.php
+++ b/src/Service/DependencyUpdater.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace OpenForgeProject\MageForge\Service;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\Driver\File;
+use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderPool;
+use OpenForgeProject\MageForge\Service\ThemeBuilder\MagentoStandard\Builder as MagentoStandardBuilder;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -13,6 +16,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Locates the theme-owned package.json files (e.g. web/tailwind for Hyva and
  * TailwindCSS themes), reports outdated packages and updates them either within
  * their semver ranges (default) or to the latest available versions (--latest).
+ * Standard Magento themes (e.g. Magento/luma) have no own package.json; for them
+ * the Node.js setup in the Magento root is updated instead, at most once per run.
  */
 class DependencyUpdater
 {
@@ -31,12 +36,23 @@ class DependencyUpdater
     private const VERSION_PATTERN = '/^[0-9a-zA-Z.+\-]+$/';
 
     /**
+     * Result of the Magento root update in this run, null while not yet processed
+     *
+     * @var DependencyUpdateResult|null
+     */
+    private ?DependencyUpdateResult $magentoRootResult = null;
+
+    /**
      * @param File $fileDriver
      * @param NodePackageManager $nodePackageManager
+     * @param BuilderPool $builderPool
+     * @param DirectoryList $directoryList
      */
     public function __construct(
         private readonly File $fileDriver,
         private readonly NodePackageManager $nodePackageManager,
+        private readonly BuilderPool $builderPool,
+        private readonly DirectoryList $directoryList,
     ) {
     }
 
@@ -71,12 +87,7 @@ class DependencyUpdater
 
         $packageDirectories = $this->getPackageDirectories($themePath);
         if (empty($packageDirectories)) {
-            $io->warning(sprintf(
-                "Theme '%s' has no own package.json. Standard Magento themes are built from the Magento "
-                . 'root Node.js setup, which is not updated by this command.',
-                $themeCode,
-            ));
-            return DependencyUpdateResult::Skipped;
+            return $this->updateMagentoRootDependencies($themeCode, $themePath, $io, $isVerbose, $latest, $dryRun);
         }
 
         $result = true;
@@ -87,6 +98,65 @@ class DependencyUpdater
         }
 
         return $result ? DependencyUpdateResult::Updated : DependencyUpdateResult::Failed;
+    }
+
+    /**
+     * Update the Magento root Node.js setup used to build standard Magento themes
+     *
+     * Standard Magento themes (e.g. Magento/luma) ship no own package.json; their
+     * assets are built with Grunt from the Node.js setup in the Magento root. That
+     * setup is shared by all standard themes, so it is processed at most once per
+     * run and the result is replayed for further standard themes.
+     *
+     * @param string $themeCode
+     * @param string $themePath
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @param bool $latest
+     * @param bool $dryRun
+     * @return DependencyUpdateResult
+     */
+    private function updateMagentoRootDependencies(
+        string $themeCode,
+        string $themePath,
+        SymfonyStyle $io,
+        bool $isVerbose,
+        bool $latest,
+        bool $dryRun,
+    ): DependencyUpdateResult {
+        if (!$this->builderPool->getBuilder($themePath) instanceof MagentoStandardBuilder) {
+            $io->warning(sprintf("Theme '%s' has no own package.json. Skipping.", $themeCode));
+            return DependencyUpdateResult::Skipped;
+        }
+
+        $rootPath = rtrim($this->directoryList->getRoot(), '/');
+        if (!$this->fileDriver->isExists($rootPath . '/' . self::PACKAGE_JSON)) {
+            $io->warning(sprintf(
+                "Theme '%s' is built from the Node.js setup in the Magento root, but the Magento root has "
+                . 'no package.json. Copy package.json.sample to package.json to set it up.',
+                $themeCode,
+            ));
+            return DependencyUpdateResult::Skipped;
+        }
+
+        if ($this->magentoRootResult !== null) {
+            $io->writeln(sprintf(
+                "  Theme '%s' uses the Magento root Node.js setup, which was already processed in this run.",
+                $themeCode,
+            ));
+            return $this->magentoRootResult;
+        }
+
+        $io->text(sprintf(
+            "Theme '%s' has no own package.json. Updating the Magento root Node.js setup it is built from.",
+            $themeCode,
+        ));
+
+        $this->magentoRootResult = $this->processPackageDirectory($rootPath, $io, $isVerbose, $latest, $dryRun)
+            ? DependencyUpdateResult::Updated
+            : DependencyUpdateResult::Failed;
+
+        return $this->magentoRootResult;
     }
 
     /**

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -14,6 +14,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class NodePackageManager
 {
     /**
+     * Map of npm dependency types to their install save flags
+     */
+    private const SAVE_FLAGS = [
+        'dependencies' => '--save',
+        'devDependencies' => '--save-dev',
+        'optionalDependencies' => '--save-optional',
+        'peerDependencies' => '--save-peer',
+    ];
+
+    /**
      * @param Shell $shell
      * @param FileDriver $fileDriver
      */
@@ -93,6 +103,131 @@ class NodePackageManager
     }
 
     /**
+     * Get a normalized list of outdated npm packages for the given directory
+     *
+     * The npm process exits with a non-zero code when outdated packages exist, so the
+     * exit code is neutralized with a trailing "true" and an empty output is treated as
+     * "everything up to date". A "|| true" must not be used here because the Magento
+     * shell command renderer converts "||" into a pipe that swallows the npm output.
+     *
+     * @param string $path
+     * @return array<int,array{name:string,current:string,wanted:string,latest:string,type:string}>
+     */
+    public function getOutdatedPackages(string $path): array
+    {
+        try {
+            $output = $this->shell->execute('cd %s && npm outdated --json --long 2>/dev/null; true', [$path]);
+        } catch (\Exception $e) {
+            return [];
+        }
+
+        if (trim($output) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($output, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $packages = [];
+        foreach ($decoded as $name => $info) {
+            // npm may report a list of entries per package (one per dependent)
+            if (is_array($info) && array_is_list($info)) {
+                $info = $info[0] ?? null;
+            }
+            if (!is_array($info)) {
+                continue;
+            }
+
+            $packages[] = [
+                'name' => (string) $name,
+                'current' => $this->getStringValue($info, 'current'),
+                'wanted' => $this->getStringValue($info, 'wanted'),
+                'latest' => $this->getStringValue($info, 'latest'),
+                'type' => $this->getStringValue($info, 'type', 'dependencies'),
+            ];
+        }
+
+        return $packages;
+    }
+
+    /**
+     * Update npm packages within the version ranges defined in package.json
+     *
+     * Only node_modules and package-lock.json are updated; package.json is left untouched.
+     *
+     * @param string $path
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @return bool
+     */
+    public function updatePackages(string $path, SymfonyStyle $io, bool $isVerbose): bool
+    {
+        try {
+            if ($isVerbose) {
+                $io->text('Running npm update...');
+            }
+            $this->shell->execute('cd %s && npm update --quiet', [$path]);
+            if ($isVerbose) {
+                $io->success('Packages updated within their semver ranges.');
+            }
+            return true;
+        } catch (\Exception $e) {
+            $io->error('Failed to update packages: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Install specific package versions with the save flag matching the dependency type
+     *
+     * @param string $path
+     * @param string $dependencyType npm dependency type (e.g. 'dependencies', 'devDependencies')
+     * @param array<string,string> $packageVersions Map of package name to version
+     * @param SymfonyStyle $io
+     * @param bool $isVerbose
+     * @return bool
+     */
+    public function installPackageVersions(
+        string $path,
+        string $dependencyType,
+        array $packageVersions,
+        SymfonyStyle $io,
+        bool $isVerbose,
+    ): bool {
+        if (empty($packageVersions)) {
+            return true;
+        }
+
+        $saveFlag = self::SAVE_FLAGS[$dependencyType] ?? '--save';
+
+        $specs = [];
+        foreach ($packageVersions as $name => $version) {
+            $specs[] = $name . '@' . $version;
+        }
+
+        $placeholders = implode(' ', array_fill(0, count($specs), '%s'));
+
+        try {
+            if ($isVerbose) {
+                $io->text(sprintf('Installing %s: %s', $dependencyType, implode(', ', $specs)));
+            }
+            $this->shell->execute(
+                sprintf('cd %%s && npm install %s --quiet %s', $saveFlag, $placeholders),
+                array_merge([$path], $specs),
+            );
+            if ($isVerbose) {
+                $io->success(sprintf('Installed %d package(s) as %s.', count($specs), $dependencyType));
+            }
+            return true;
+        } catch (\Exception $e) {
+            $io->error('Failed to install packages: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
      * Check for outdated npm packages and report them
      *
      * @param string $path
@@ -112,5 +247,19 @@ class NodePackageManager
                 $io->warning('Failed to check outdated packages: ' . $e->getMessage());
             }
         }
+    }
+
+    /**
+     * Read a string value from decoded npm JSON output
+     *
+     * @param array<mixed> $info
+     * @param string $key
+     * @param string $default
+     * @return string
+     */
+    private function getStringValue(array $info, string $key, string $default = '-'): string
+    {
+        $value = $info[$key] ?? null;
+        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -106,28 +106,26 @@ class NodePackageManager
      * Get a normalized list of outdated npm packages for the given directory
      *
      * The npm process exits with a non-zero code when outdated packages exist, so the
-     * exit code is neutralized with a trailing "true" and an empty output is treated as
-     * "everything up to date". A "|| true" must not be used here because the Magento
-     * shell command renderer converts "||" into a pipe that swallows the npm output.
+     * exit code is neutralized with a trailing "true". A "|| true" must not be used here
+     * because the Magento shell command renderer converts "||" into a pipe that swallows
+     * the npm output. npm always prints a JSON object ("{}" when everything is up to
+     * date), so empty or invalid output signals a failed check rather than "up to date".
      *
      * @param string $path
-     * @return array<int,array{name:string,current:string,wanted:string,latest:string,type:string}>
+     * @return array<int,array{name:string,current:string,wanted:string,latest:string,type:string}>|null
+     *         Null when the outdated check itself failed
      */
-    public function getOutdatedPackages(string $path): array
+    public function getOutdatedPackages(string $path): ?array
     {
         try {
             $output = $this->shell->execute('cd %s && npm outdated --json --long 2>/dev/null; true', [$path]);
         } catch (\Exception $e) {
-            return [];
-        }
-
-        if (trim($output) === '') {
-            return [];
+            return null;
         }
 
         $decoded = json_decode($output, true);
-        if (!is_array($decoded)) {
-            return [];
+        if (!is_array($decoded) || isset($decoded['error'])) {
+            return null;
         }
 
         $packages = [];

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -250,7 +250,7 @@ class NodePackageManager
     /**
      * Read a string value from decoded npm JSON output
      *
-     * @param array<mixed> $info
+     * @param array<string, mixed> $info
      * @param string $key
      * @param string $default
      * @return string

--- a/src/Service/NodePackageManager.php
+++ b/src/Service/NodePackageManager.php
@@ -250,7 +250,7 @@ class NodePackageManager
     /**
      * Read a string value from decoded npm JSON output
      *
-     * @param array<string, mixed> $info
+     * @param array<mixed> $info
      * @param string $key
      * @param string $default
      * @return string

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,6 +25,8 @@
                               OpenForgeProject\MageForge\Console\Command\Theme\TokensCommand</item>
                         <item name="mageforge_dev_inspector" xsi:type="object">
                               OpenForgeProject\MageForge\Console\Command\Dev\InspectorCommand</item>
+                        <item name="mageforge_dependencies_update" xsi:type="object">
+                              OpenForgeProject\MageForge\Console\Command\Dependencies\UpdateCommand</item>
                   </argument>
             </arguments>
       </type>

--- a/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
+++ b/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Test\Unit\Console\Command\Dependencies;
+
+use Magento\Framework\Console\Cli;
+use OpenForgeProject\MageForge\Console\Command\Dependencies\UpdateCommand;
+use OpenForgeProject\MageForge\Model\ThemeList;
+use OpenForgeProject\MageForge\Model\ThemePath;
+use OpenForgeProject\MageForge\Service\DependencyUpdater;
+use OpenForgeProject\MageForge\Service\ThemeSuggester;
+use OpenForgeProject\MageForge\Test\Unit\Console\Command\Theme\FakeThemeWithTitle;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateCommandTest extends TestCase
+{
+    private DependencyUpdater&MockObject $dependencyUpdater;
+    private ThemePath&MockObject $themePath;
+    private ThemeList&MockObject $themeList;
+    private ThemeSuggester&MockObject $themeSuggester;
+    private UpdateCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->dependencyUpdater = $this->createMock(DependencyUpdater::class);
+        $this->themePath = $this->createMock(ThemePath::class);
+        $this->themeList = $this->createMock(ThemeList::class);
+        $this->themeSuggester = $this->createMock(ThemeSuggester::class);
+        $this->command = new UpdateCommand(
+            $this->dependencyUpdater,
+            $this->themePath,
+            $this->themeList,
+            $this->themeSuggester,
+        );
+    }
+
+    public function testCommandNameAndAlias(): void
+    {
+        $this->assertSame('mageforge:dependencies:update', $this->command->getName());
+        $this->assertSame(['dependencies:update'], $this->command->getAliases());
+    }
+
+    public function testUpdatesSingleThemeAndSuggestsRebuild(): void
+    {
+        $this->themePath->method('getPath')->with('Vendor/theme')->willReturn('/path');
+        $this->dependencyUpdater
+            ->expects($this->once())
+            ->method('updateThemeDependencies')
+            ->with('Vendor/theme', '/path', $this->anything(), false, false, false)
+            ->willReturn(true);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/theme']]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Updating dependencies for theme: Vendor/theme', $display);
+        $this->assertStringContainsString('Updated dependencies for 1 theme(s)', $display);
+        $this->assertStringContainsString('mageforge:theme:build Vendor/theme', $display);
+    }
+
+    public function testPassesLatestAndDryRunOptionsToService(): void
+    {
+        $this->themePath->method('getPath')->willReturn('/path');
+        $this->dependencyUpdater
+            ->expects($this->once())
+            ->method('updateThemeDependencies')
+            ->with('Vendor/theme', '/path', $this->anything(), false, true, true)
+            ->willReturn(true);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute([
+            'themeCodes' => ['Vendor/theme'],
+            '--latest' => true,
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('DRY RUN MODE: No dependencies will be changed', $display);
+        $this->assertStringContainsString('Checked dependencies for 1 theme(s)', $display);
+        $this->assertStringNotContainsString('mageforge:theme:build', $display);
+    }
+
+    public function testProcessesMultipleThemesWithSectionsPerTheme(): void
+    {
+        $this->themePath->method('getPath')->willReturn('/path');
+        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(true);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/one', 'Vendor/two']]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Updating dependencies 1 of 2: Vendor/one', $display);
+        $this->assertStringContainsString('Updating dependencies 2 of 2: Vendor/two', $display);
+        $this->assertStringContainsString('Updated dependencies for 2 theme(s)', $display);
+    }
+
+    public function testReturnsFailureWhenAllThemesFail(): void
+    {
+        $this->themePath->method('getPath')->willReturn('/path');
+        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(false);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/theme']]);
+
+        $this->assertSame(Cli::RETURN_FAILURE, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('No theme dependencies were updated.', $display);
+        $this->assertStringContainsString('Failed to process 1 theme(s): Vendor/theme', $display);
+    }
+
+    public function testReportsInvalidThemeWithoutCallingService(): void
+    {
+        $this->themePath->method('getPath')->willReturn(null);
+        $this->themeSuggester->method('findSimilarThemes')->willReturn([]);
+        $this->dependencyUpdater->expects($this->never())->method('updateThemeDependencies');
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/unknown']]);
+
+        $this->assertSame(Cli::RETURN_FAILURE, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString("Theme 'Vendor/unknown' is not installed", $display);
+        $this->assertStringContainsString('Failed to process 1 theme(s): Vendor/unknown', $display);
+    }
+
+    public function testListsAvailableThemesWhenNoThemeGivenNonInteractively(): void
+    {
+        $theme = new FakeThemeWithTitle('Vendor/theme', 'Vendor Theme');
+        $this->themeList->method('getAllThemes')->willReturn([$theme]);
+        $this->dependencyUpdater->expects($this->never())->method('updateThemeDependencies');
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('No theme specified. Available themes:', $display);
+        $this->assertStringContainsString('Vendor/theme', $display);
+        $this->assertStringContainsString('mageforge:dependencies:update <theme-code>', $display);
+    }
+
+    public function testContinuesWithRemainingThemesWhenOneFails(): void
+    {
+        $this->themePath->method('getPath')->willReturn('/path');
+        $this->dependencyUpdater
+            ->method('updateThemeDependencies')
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/broken', 'Vendor/fine']]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Updated dependencies for 1 theme(s)', $display);
+        $this->assertStringContainsString('Failed to process 1 theme(s): Vendor/broken', $display);
+    }
+}

--- a/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
+++ b/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
@@ -18,10 +18,25 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class UpdateCommandTest extends TestCase
 {
-    private DependencyUpdater&MockObject $dependencyUpdater;
-    private ThemePath&MockObject $themePath;
-    private ThemeList&MockObject $themeList;
-    private ThemeSuggester&MockObject $themeSuggester;
+    /**
+     * @var DependencyUpdater&MockObject
+     */
+    private $dependencyUpdater;
+    /**
+     * @var ThemePath&MockObject
+     */
+    private $themePath;
+    /**
+     * @var ThemeList&MockObject
+     */
+    private $themeList;
+    /**
+     * @var ThemeSuggester&MockObject
+     */
+    private $themeSuggester;
+    /**
+     * @var UpdateCommand
+     */
     private UpdateCommand $command;
 
     protected function setUp(): void

--- a/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
+++ b/tests/Unit/Console/Command/Dependencies/UpdateCommandTest.php
@@ -8,6 +8,7 @@ use Magento\Framework\Console\Cli;
 use OpenForgeProject\MageForge\Console\Command\Dependencies\UpdateCommand;
 use OpenForgeProject\MageForge\Model\ThemeList;
 use OpenForgeProject\MageForge\Model\ThemePath;
+use OpenForgeProject\MageForge\Service\DependencyUpdateResult;
 use OpenForgeProject\MageForge\Service\DependencyUpdater;
 use OpenForgeProject\MageForge\Service\ThemeSuggester;
 use OpenForgeProject\MageForge\Test\Unit\Console\Command\Theme\FakeThemeWithTitle;
@@ -50,7 +51,7 @@ class UpdateCommandTest extends TestCase
             ->expects($this->once())
             ->method('updateThemeDependencies')
             ->with('Vendor/theme', '/path', $this->anything(), false, false, false)
-            ->willReturn(true);
+            ->willReturn(DependencyUpdateResult::Updated);
 
         $tester = new CommandTester($this->command);
         $exitCode = $tester->execute(['themeCodes' => ['Vendor/theme']]);
@@ -69,7 +70,7 @@ class UpdateCommandTest extends TestCase
             ->expects($this->once())
             ->method('updateThemeDependencies')
             ->with('Vendor/theme', '/path', $this->anything(), false, true, true)
-            ->willReturn(true);
+            ->willReturn(DependencyUpdateResult::Updated);
 
         $tester = new CommandTester($this->command);
         $exitCode = $tester->execute([
@@ -88,7 +89,7 @@ class UpdateCommandTest extends TestCase
     public function testProcessesMultipleThemesWithSectionsPerTheme(): void
     {
         $this->themePath->method('getPath')->willReturn('/path');
-        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(true);
+        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(DependencyUpdateResult::Updated);
 
         $tester = new CommandTester($this->command);
         $exitCode = $tester->execute(['themeCodes' => ['Vendor/one', 'Vendor/two']]);
@@ -103,7 +104,7 @@ class UpdateCommandTest extends TestCase
     public function testReturnsFailureWhenAllThemesFail(): void
     {
         $this->themePath->method('getPath')->willReturn('/path');
-        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(false);
+        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(DependencyUpdateResult::Failed);
 
         $tester = new CommandTester($this->command);
         $exitCode = $tester->execute(['themeCodes' => ['Vendor/theme']]);
@@ -112,6 +113,20 @@ class UpdateCommandTest extends TestCase
         $display = $tester->getDisplay();
         $this->assertStringContainsString('No theme dependencies were updated.', $display);
         $this->assertStringContainsString('Failed to process 1 theme(s): Vendor/theme', $display);
+    }
+
+    public function testReturnsSuccessWhenAllThemesAreSkipped(): void
+    {
+        $this->themePath->method('getPath')->willReturn('/path');
+        $this->dependencyUpdater->method('updateThemeDependencies')->willReturn(DependencyUpdateResult::Skipped);
+
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute(['themeCodes' => ['Vendor/theme']]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Skipped 1 theme(s): Vendor/theme', $display);
+        $this->assertStringNotContainsString('Failed to process', $display);
     }
 
     public function testReportsInvalidThemeWithoutCallingService(): void
@@ -150,7 +165,7 @@ class UpdateCommandTest extends TestCase
         $this->themePath->method('getPath')->willReturn('/path');
         $this->dependencyUpdater
             ->method('updateThemeDependencies')
-            ->willReturnOnConsecutiveCalls(false, true);
+            ->willReturnOnConsecutiveCalls(DependencyUpdateResult::Failed, DependencyUpdateResult::Updated);
 
         $tester = new CommandTester($this->command);
         $exitCode = $tester->execute(['themeCodes' => ['Vendor/broken', 'Vendor/fine']]);

--- a/tests/Unit/Service/DependencyUpdaterTest.php
+++ b/tests/Unit/Service/DependencyUpdaterTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace OpenForgeProject\MageForge\Test\Unit\Service;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\Driver\File;
 use OpenForgeProject\MageForge\Service\DependencyUpdater;
 use OpenForgeProject\MageForge\Service\DependencyUpdateResult;
 use OpenForgeProject\MageForge\Service\NodePackageManager;
+use OpenForgeProject\MageForge\Service\ThemeBuilder\BuilderPool;
+use OpenForgeProject\MageForge\Service\ThemeBuilder\MagentoStandard\Builder as MagentoStandardBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -16,6 +19,8 @@ class DependencyUpdaterTest extends TestCase
 {
     private File&MockObject $fileDriver;
     private NodePackageManager&MockObject $nodePackageManager;
+    private BuilderPool&MockObject $builderPool;
+    private DirectoryList&MockObject $directoryList;
     private SymfonyStyle&MockObject $io;
     private DependencyUpdater $updater;
 
@@ -23,8 +28,21 @@ class DependencyUpdaterTest extends TestCase
     {
         $this->fileDriver = $this->createMock(File::class);
         $this->nodePackageManager = $this->createMock(NodePackageManager::class);
+        $this->builderPool = $this->createMock(BuilderPool::class);
+        $this->directoryList = $this->createMock(DirectoryList::class);
+        $this->directoryList->method('getRoot')->willReturn('/magento-root');
         $this->io = $this->createMock(SymfonyStyle::class);
-        $this->updater = new DependencyUpdater($this->fileDriver, $this->nodePackageManager);
+        $this->updater = new DependencyUpdater(
+            $this->fileDriver,
+            $this->nodePackageManager,
+            $this->builderPool,
+            $this->directoryList,
+        );
+    }
+
+    private function actAsMagentoStandardTheme(): void
+    {
+        $this->builderPool->method('getBuilder')->willReturn($this->createMock(MagentoStandardBuilder::class));
     }
 
     /**
@@ -98,16 +116,18 @@ class DependencyUpdaterTest extends TestCase
         ));
     }
 
-    public function testWarnsWhenThemeHasNoOwnPackageJson(): void
+    public function testSkipsNonStandardThemesWithoutOwnPackageJson(): void
     {
         $this->fileDriver->method('isExists')->willReturn(false);
+        $this->builderPool->method('getBuilder')->willReturn(null);
         $this->io
             ->expects($this->once())
             ->method('warning')
             ->with($this->stringContains('has no own package.json'));
+        $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
 
         $this->assertSame(DependencyUpdateResult::Skipped, $this->updater->updateThemeDependencies(
-            'Magento/luma',
+            'Vendor/csstheme',
             '/theme',
             $this->io,
             false,
@@ -400,6 +420,125 @@ class DependencyUpdaterTest extends TestCase
         $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // Magento root fallback for standard themes (Magento/luma, Magento/blank)
+    // -------------------------------------------------------------------------
+
+    public function testUpdatesMagentoRootForStandardThemes(): void
+    {
+        $this->actAsMagentoStandardTheme();
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/luma/web/tailwind/package.json', false],
+            ['/luma/package.json', false],
+            ['/magento-root/package.json', true],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->expects($this->once())
+            ->method('getOutdatedPackages')
+            ->with('/magento-root')
+            ->willReturn([]);
+
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
+            'Magento/luma',
+            '/luma',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testSkipsStandardThemeWhenMagentoRootHasNoPackageJson(): void
+    {
+        $this->actAsMagentoStandardTheme();
+        $this->fileDriver->method('isExists')->willReturn(false);
+        $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('package.json.sample'));
+
+        $this->assertSame(DependencyUpdateResult::Skipped, $this->updater->updateThemeDependencies(
+            'Magento/luma',
+            '/luma',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testUpdatesMagentoRootOnlyOncePerRun(): void
+    {
+        $this->actAsMagentoStandardTheme();
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/luma/web/tailwind/package.json', false],
+            ['/luma/package.json', false],
+            ['/blank/web/tailwind/package.json', false],
+            ['/blank/package.json', false],
+            ['/magento-root/package.json', true],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->expects($this->once())
+            ->method('getOutdatedPackages')
+            ->with('/magento-root')
+            ->willReturn([]);
+
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
+            'Magento/luma',
+            '/luma',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
+            'Magento/blank',
+            '/blank',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testReplaysMagentoRootFailureForSubsequentStandardThemes(): void
+    {
+        $this->actAsMagentoStandardTheme();
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/luma/web/tailwind/package.json', false],
+            ['/luma/package.json', false],
+            ['/blank/web/tailwind/package.json', false],
+            ['/blank/package.json', false],
+            ['/magento-root/package.json', true],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->expects($this->once())
+            ->method('getOutdatedPackages')
+            ->with('/magento-root')
+            ->willReturn(null);
+
+        $this->assertSame(DependencyUpdateResult::Failed, $this->updater->updateThemeDependencies(
+            'Magento/luma',
+            '/luma',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+        $this->assertSame(DependencyUpdateResult::Failed, $this->updater->updateThemeDependencies(
+            'Magento/blank',
+            '/blank',
             $this->io,
             false,
             false,

--- a/tests/Unit/Service/DependencyUpdaterTest.php
+++ b/tests/Unit/Service/DependencyUpdaterTest.php
@@ -90,8 +90,9 @@ class DependencyUpdaterTest extends TestCase
 
     public function testDetectsVendorThemes(): void
     {
-        $this->assertTrue($this->updater->isVendorTheme('/var/www/vendor/hyva-themes/magento2-default-theme'));
-        $this->assertFalse($this->updater->isVendorTheme('/var/www/app/design/frontend/Vendor/theme'));
+        $this->assertTrue($this->updater->isVendorTheme('/magento-root/vendor/hyva-themes/magento2-default-theme'));
+        $this->assertFalse($this->updater->isVendorTheme('/magento-root/app/design/frontend/Vendor/theme'));
+        $this->assertFalse($this->updater->isVendorTheme('/magento-root/app/design/frontend/vendor/theme'));
     }
 
     // -------------------------------------------------------------------------
@@ -108,7 +109,7 @@ class DependencyUpdaterTest extends TestCase
 
         $this->assertSame(DependencyUpdateResult::Skipped, $this->updater->updateThemeDependencies(
             'Hyva/default',
-            '/var/www/vendor/hyva-themes/magento2-default-theme',
+            '/magento-root/vendor/hyva-themes/magento2-default-theme',
             $this->io,
             false,
             false,

--- a/tests/Unit/Service/DependencyUpdaterTest.php
+++ b/tests/Unit/Service/DependencyUpdaterTest.php
@@ -17,11 +17,29 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class DependencyUpdaterTest extends TestCase
 {
-    private File&MockObject $fileDriver;
-    private NodePackageManager&MockObject $nodePackageManager;
-    private BuilderPool&MockObject $builderPool;
-    private DirectoryList&MockObject $directoryList;
-    private SymfonyStyle&MockObject $io;
+    /**
+     * @var File&MockObject
+     */
+    private $fileDriver;
+    /**
+     * @var NodePackageManager&MockObject
+     */
+    private $nodePackageManager;
+    /**
+     * @var BuilderPool&MockObject
+     */
+    private $builderPool;
+    /**
+     * @var DirectoryList&MockObject
+     */
+    private $directoryList;
+    /**
+     * @var SymfonyStyle&MockObject
+     */
+    private $io;
+    /**
+     * @var DependencyUpdater
+     */
     private DependencyUpdater $updater;
 
     protected function setUp(): void

--- a/tests/Unit/Service/DependencyUpdaterTest.php
+++ b/tests/Unit/Service/DependencyUpdaterTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenForgeProject\MageForge\Test\Unit\Service;
+
+use Magento\Framework\Filesystem\Driver\File;
+use OpenForgeProject\MageForge\Service\DependencyUpdater;
+use OpenForgeProject\MageForge\Service\NodePackageManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DependencyUpdaterTest extends TestCase
+{
+    private File&MockObject $fileDriver;
+    private NodePackageManager&MockObject $nodePackageManager;
+    private SymfonyStyle&MockObject $io;
+    private DependencyUpdater $updater;
+
+    protected function setUp(): void
+    {
+        $this->fileDriver = $this->createMock(File::class);
+        $this->nodePackageManager = $this->createMock(NodePackageManager::class);
+        $this->io = $this->createMock(SymfonyStyle::class);
+        $this->updater = new DependencyUpdater($this->fileDriver, $this->nodePackageManager);
+    }
+
+    /**
+     * @return array{name: string, current: string, wanted: string, latest: string, type: string}
+     */
+    private function outdatedPackage(
+        string $name = 'tailwindcss',
+        string $current = '3.4.1',
+        string $wanted = '3.4.17',
+        string $latest = '4.1.5',
+        string $type = 'devDependencies',
+    ): array {
+        return [
+            'name' => $name,
+            'current' => $current,
+            'wanted' => $wanted,
+            'latest' => $latest,
+            'type' => $type,
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // getPackageDirectories / isVendorTheme
+    // -------------------------------------------------------------------------
+
+    public function testFindsPackageJsonInTailwindAndThemeRoot(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', true],
+        ]);
+
+        $this->assertSame(
+            ['/theme/web/tailwind', '/theme'],
+            $this->updater->getPackageDirectories('/theme/'),
+        );
+    }
+
+    public function testReturnsEmptyListWhenThemeHasNoPackageJson(): void
+    {
+        $this->fileDriver->method('isExists')->willReturn(false);
+
+        $this->assertSame([], $this->updater->getPackageDirectories('/theme'));
+    }
+
+    public function testDetectsVendorThemes(): void
+    {
+        $this->assertTrue($this->updater->isVendorTheme('/var/www/vendor/hyva-themes/magento2-default-theme'));
+        $this->assertFalse($this->updater->isVendorTheme('/var/www/app/design/frontend/Vendor/theme'));
+    }
+
+    // -------------------------------------------------------------------------
+    // updateThemeDependencies
+    // -------------------------------------------------------------------------
+
+    public function testSkipsVendorThemesWithWarning(): void
+    {
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('managed by Composer'));
+        $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
+
+        $this->assertFalse($this->updater->updateThemeDependencies(
+            'Hyva/default',
+            '/var/www/vendor/hyva-themes/magento2-default-theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testWarnsWhenThemeHasNoOwnPackageJson(): void
+    {
+        $this->fileDriver->method('isExists')->willReturn(false);
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('has no own package.json'));
+
+        $this->assertFalse($this->updater->updateThemeDependencies(
+            'Magento/luma',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testReportsUpToDatePackagesWithoutUpdating(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager->method('getOutdatedPackages')->willReturn([]);
+        $this->nodePackageManager->expects($this->never())->method('updatePackages');
+        $this->io
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('are up to date'));
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testInstallsNodeModulesFirstWhenMissing(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->with('/theme/web/tailwind/node_modules')->willReturn(false);
+        $this->nodePackageManager
+            ->expects($this->once())
+            ->method('installNodeModules')
+            ->with('/theme/web/tailwind')
+            ->willReturn(true);
+        $this->nodePackageManager->method('getOutdatedPackages')->willReturn([]);
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testFailsWhenInitialInstallFails(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(false);
+        $this->nodePackageManager->method('installNodeModules')->willReturn(false);
+        $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
+
+        $this->assertFalse($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testUpdatesWithinSemverRangesByDefault(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->method('getOutdatedPackages')
+            ->willReturnOnConsecutiveCalls([$this->outdatedPackage()], []);
+        $this->nodePackageManager
+            ->expects($this->once())
+            ->method('updatePackages')
+            ->with('/theme/web/tailwind')
+            ->willReturn(true);
+        $this->nodePackageManager->expects($this->never())->method('installPackageVersions');
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testHintsAtLatestOptionWhenMajorUpdatesRemain(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->method('getOutdatedPackages')
+            ->willReturnOnConsecutiveCalls([$this->outdatedPackage()], [$this->outdatedPackage(current: '3.4.17')]);
+        $this->nodePackageManager->method('updatePackages')->willReturn(true);
+        $this->io
+            ->expects($this->once())
+            ->method('note')
+            ->with($this->stringContains('--latest'));
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testDryRunOnlyReportsWithoutChangingAnything(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->nodePackageManager->method('getOutdatedPackages')->willReturn([$this->outdatedPackage()]);
+        $this->nodePackageManager->expects($this->never())->method('installNodeModules');
+        $this->nodePackageManager->expects($this->never())->method('updatePackages');
+        $this->nodePackageManager->expects($this->never())->method('installPackageVersions');
+        $this->io
+            ->expects($this->once())
+            ->method('note')
+            ->with($this->stringContains('Dry run: would update 1 package(s)'));
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            true,
+        ));
+    }
+
+    public function testLatestModeInstallsPinnedVersionsGroupedByType(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->method('getOutdatedPackages')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $this->outdatedPackage(),
+                    $this->outdatedPackage(name: 'postcss', current: '8.4.0', wanted: '8.5.0', latest: '8.5.0'),
+                    $this->outdatedPackage(name: 'alpinejs', current: '3.13.0', latest: '3.14.9', type: 'dependencies'),
+                ],
+                [],
+            );
+        $installedGroups = [];
+        $this->nodePackageManager
+            ->method('installPackageVersions')
+            ->willReturnCallback(
+                function (string $path, string $type, array $packages) use (&$installedGroups): bool {
+                    $installedGroups[$type] = $packages;
+                    $this->assertSame('/theme/web/tailwind', $path);
+                    return true;
+                },
+            );
+        $this->nodePackageManager->expects($this->never())->method('updatePackages');
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            true,
+            false,
+        ));
+        $this->assertSame([
+            'devDependencies' => ['tailwindcss' => '4.1.5', 'postcss' => '8.5.0'],
+            'dependencies' => ['alpinejs' => '3.14.9'],
+        ], $installedGroups);
+    }
+
+    public function testLatestModeSkipsUnsafePackageSpecsWithWarning(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->method('getOutdatedPackages')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $this->outdatedPackage(name: 'evil; rm -rf /', latest: '1.0.0'),
+                    $this->outdatedPackage(name: 'nolatest', latest: '-'),
+                ],
+                [],
+            );
+        $this->nodePackageManager->expects($this->never())->method('installPackageVersions');
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('unexpected name or version'));
+
+        $this->assertTrue($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            true,
+            false,
+        ));
+    }
+
+    public function testFailsWhenNpmUpdateFails(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager->method('getOutdatedPackages')->willReturn([$this->outdatedPackage()]);
+        $this->nodePackageManager->method('updatePackages')->willReturn(false);
+
+        $this->assertFalse($this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+}

--- a/tests/Unit/Service/DependencyUpdaterTest.php
+++ b/tests/Unit/Service/DependencyUpdaterTest.php
@@ -6,6 +6,7 @@ namespace OpenForgeProject\MageForge\Test\Unit\Service;
 
 use Magento\Framework\Filesystem\Driver\File;
 use OpenForgeProject\MageForge\Service\DependencyUpdater;
+use OpenForgeProject\MageForge\Service\DependencyUpdateResult;
 use OpenForgeProject\MageForge\Service\NodePackageManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -87,7 +88,7 @@ class DependencyUpdaterTest extends TestCase
             ->with($this->stringContains('managed by Composer'));
         $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
 
-        $this->assertFalse($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Skipped, $this->updater->updateThemeDependencies(
             'Hyva/default',
             '/var/www/vendor/hyva-themes/magento2-default-theme',
             $this->io,
@@ -105,7 +106,7 @@ class DependencyUpdaterTest extends TestCase
             ->method('warning')
             ->with($this->stringContains('has no own package.json'));
 
-        $this->assertFalse($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Skipped, $this->updater->updateThemeDependencies(
             'Magento/luma',
             '/theme',
             $this->io,
@@ -129,7 +130,7 @@ class DependencyUpdaterTest extends TestCase
             ->method('writeln')
             ->with($this->stringContains('are up to date'));
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -149,11 +150,11 @@ class DependencyUpdaterTest extends TestCase
         $this->nodePackageManager
             ->expects($this->once())
             ->method('installNodeModules')
-            ->with('/theme/web/tailwind')
+            ->with('/theme/web/tailwind', $this->io, false)
             ->willReturn(true);
         $this->nodePackageManager->method('getOutdatedPackages')->willReturn([]);
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -173,7 +174,7 @@ class DependencyUpdaterTest extends TestCase
         $this->nodePackageManager->method('installNodeModules')->willReturn(false);
         $this->nodePackageManager->expects($this->never())->method('getOutdatedPackages');
 
-        $this->assertFalse($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Failed, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -200,7 +201,7 @@ class DependencyUpdaterTest extends TestCase
             ->willReturn(true);
         $this->nodePackageManager->expects($this->never())->method('installPackageVersions');
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -226,7 +227,7 @@ class DependencyUpdaterTest extends TestCase
             ->method('note')
             ->with($this->stringContains('--latest'));
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -251,7 +252,7 @@ class DependencyUpdaterTest extends TestCase
             ->method('note')
             ->with($this->stringContains('Dry run: would update 1 package(s)'));
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -290,7 +291,7 @@ class DependencyUpdaterTest extends TestCase
             );
         $this->nodePackageManager->expects($this->never())->method('updatePackages');
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -326,7 +327,7 @@ class DependencyUpdaterTest extends TestCase
             ->method('warning')
             ->with($this->stringContains('unexpected name or version'));
 
-        $this->assertTrue($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,
@@ -346,7 +347,57 @@ class DependencyUpdaterTest extends TestCase
         $this->nodePackageManager->method('getOutdatedPackages')->willReturn([$this->outdatedPackage()]);
         $this->nodePackageManager->method('updatePackages')->willReturn(false);
 
-        $this->assertFalse($this->updater->updateThemeDependencies(
+        $this->assertSame(DependencyUpdateResult::Failed, $this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testFailsWhenOutdatedCheckFails(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager->method('getOutdatedPackages')->willReturn(null);
+        $this->nodePackageManager->expects($this->never())->method('updatePackages');
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Could not check for outdated packages'));
+
+        $this->assertSame(DependencyUpdateResult::Failed, $this->updater->updateThemeDependencies(
+            'Vendor/theme',
+            '/theme',
+            $this->io,
+            false,
+            false,
+            false,
+        ));
+    }
+
+    public function testWarnsWhenPostUpdateCheckFails(): void
+    {
+        $this->fileDriver->method('isExists')->willReturnMap([
+            ['/theme/web/tailwind/package.json', true],
+            ['/theme/package.json', false],
+        ]);
+        $this->fileDriver->method('isDirectory')->willReturn(true);
+        $this->nodePackageManager
+            ->method('getOutdatedPackages')
+            ->willReturnOnConsecutiveCalls([$this->outdatedPackage()], null);
+        $this->nodePackageManager->method('updatePackages')->willReturn(true);
+        $this->io
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Could not verify the update result'));
+
+        $this->assertSame(DependencyUpdateResult::Updated, $this->updater->updateThemeDependencies(
             'Vendor/theme',
             '/theme',
             $this->io,

--- a/tests/Unit/Service/NodePackageManagerTest.php
+++ b/tests/Unit/Service/NodePackageManagerTest.php
@@ -211,4 +211,194 @@ class NodePackageManagerTest extends TestCase
 
         $this->packageManager->checkOutdatedPackages('/theme', $this->io);
     }
+
+    // -------------------------------------------------------------------------
+    // getOutdatedPackages
+    // -------------------------------------------------------------------------
+
+    public function testParsesOutdatedPackagesFromNpmJsonOutput(): void
+    {
+        $this->shell
+            ->expects($this->once())
+            ->method('execute')
+            ->with('cd %s && npm outdated --json --long 2>/dev/null; true', ['/theme'])
+            ->willReturn(json_encode([
+                'tailwindcss' => [
+                    'current' => '3.4.1',
+                    'wanted' => '3.4.17',
+                    'latest' => '4.1.5',
+                    'type' => 'devDependencies',
+                ],
+                'alpinejs' => [
+                    'current' => '3.13.0',
+                    'wanted' => '3.14.9',
+                    'latest' => '3.14.9',
+                    'type' => 'dependencies',
+                ],
+            ], JSON_THROW_ON_ERROR));
+
+        $packages = $this->packageManager->getOutdatedPackages('/theme');
+
+        $this->assertSame([
+            [
+                'name' => 'tailwindcss',
+                'current' => '3.4.1',
+                'wanted' => '3.4.17',
+                'latest' => '4.1.5',
+                'type' => 'devDependencies',
+            ],
+            [
+                'name' => 'alpinejs',
+                'current' => '3.13.0',
+                'wanted' => '3.14.9',
+                'latest' => '3.14.9',
+                'type' => 'dependencies',
+            ],
+        ], $packages);
+    }
+
+    public function testNormalizesListEntriesAndMissingFields(): void
+    {
+        $this->shell->method('execute')->willReturn(json_encode([
+            'postcss' => [
+                ['wanted' => '8.5.0', 'latest' => '8.5.0'],
+                ['wanted' => '8.4.0', 'latest' => '8.5.0'],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $packages = $this->packageManager->getOutdatedPackages('/theme');
+
+        $this->assertSame([
+            [
+                'name' => 'postcss',
+                'current' => '-',
+                'wanted' => '8.5.0',
+                'latest' => '8.5.0',
+                'type' => 'dependencies',
+            ],
+        ], $packages);
+    }
+
+    public function testReturnsEmptyListWhenEverythingIsUpToDate(): void
+    {
+        $this->shell->method('execute')->willReturn('');
+
+        $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
+    }
+
+    public function testReturnsEmptyListOnInvalidJsonOutput(): void
+    {
+        $this->shell->method('execute')->willReturn('npm ERR! something went wrong');
+
+        $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
+    }
+
+    public function testReturnsEmptyListWhenShellExecutionFails(): void
+    {
+        $this->shell->method('execute')->willThrowException(new \RuntimeException('npm not found'));
+
+        $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
+    }
+
+    // -------------------------------------------------------------------------
+    // updatePackages
+    // -------------------------------------------------------------------------
+
+    public function testRunsNpmUpdate(): void
+    {
+        $this->shell
+            ->expects($this->once())
+            ->method('execute')
+            ->with('cd %s && npm update --quiet', ['/theme']);
+
+        $this->assertTrue($this->packageManager->updatePackages('/theme', $this->io, false));
+    }
+
+    public function testReportsSuccessInVerboseModeAfterUpdate(): void
+    {
+        $this->io->expects($this->once())->method('text')->with('Running npm update...');
+        $this->io->expects($this->once())->method('success')->with('Packages updated within their semver ranges.');
+
+        $this->assertTrue($this->packageManager->updatePackages('/theme', $this->io, true));
+    }
+
+    public function testReturnsFalseAndPrintsErrorWhenUpdateFails(): void
+    {
+        $this->shell->method('execute')->willThrowException(new \RuntimeException('registry unreachable'));
+        $this->io
+            ->expects($this->once())
+            ->method('error')
+            ->with('Failed to update packages: registry unreachable');
+
+        $this->assertFalse($this->packageManager->updatePackages('/theme', $this->io, false));
+    }
+
+    // -------------------------------------------------------------------------
+    // installPackageVersions
+    // -------------------------------------------------------------------------
+
+    public function testInstallsPackagesWithSaveDevFlagForDevDependencies(): void
+    {
+        $this->shell
+            ->expects($this->once())
+            ->method('execute')
+            ->with(
+                'cd %s && npm install --save-dev --quiet %s %s',
+                ['/theme', 'tailwindcss@4.1.5', 'postcss@8.5.0'],
+            );
+
+        $this->assertTrue($this->packageManager->installPackageVersions(
+            '/theme',
+            'devDependencies',
+            ['tailwindcss' => '4.1.5', 'postcss' => '8.5.0'],
+            $this->io,
+            false,
+        ));
+    }
+
+    public function testInstallsPackagesWithSaveFlagForUnknownDependencyType(): void
+    {
+        $this->shell
+            ->expects($this->once())
+            ->method('execute')
+            ->with('cd %s && npm install --save --quiet %s', ['/theme', 'alpinejs@3.14.9']);
+
+        $this->assertTrue($this->packageManager->installPackageVersions(
+            '/theme',
+            'somethingUnknown',
+            ['alpinejs' => '3.14.9'],
+            $this->io,
+            false,
+        ));
+    }
+
+    public function testSkipsShellExecutionForEmptyPackageList(): void
+    {
+        $this->shell->expects($this->never())->method('execute');
+
+        $this->assertTrue($this->packageManager->installPackageVersions(
+            '/theme',
+            'dependencies',
+            [],
+            $this->io,
+            false,
+        ));
+    }
+
+    public function testReturnsFalseAndPrintsErrorWhenInstallOfVersionsFails(): void
+    {
+        $this->shell->method('execute')->willThrowException(new \RuntimeException('E404 not found'));
+        $this->io
+            ->expects($this->once())
+            ->method('error')
+            ->with('Failed to install packages: E404 not found');
+
+        $this->assertFalse($this->packageManager->installPackageVersions(
+            '/theme',
+            'dependencies',
+            ['alpinejs' => '3.14.9'],
+            $this->io,
+            false,
+        ));
+    }
 }

--- a/tests/Unit/Service/NodePackageManagerTest.php
+++ b/tests/Unit/Service/NodePackageManagerTest.php
@@ -281,23 +281,39 @@ class NodePackageManagerTest extends TestCase
 
     public function testReturnsEmptyListWhenEverythingIsUpToDate(): void
     {
-        $this->shell->method('execute')->willReturn('');
+        $this->shell->method('execute')->willReturn('{}');
 
         $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
     }
 
-    public function testReturnsEmptyListOnInvalidJsonOutput(): void
+    public function testReturnsNullOnEmptyOutput(): void
+    {
+        $this->shell->method('execute')->willReturn('');
+
+        $this->assertNull($this->packageManager->getOutdatedPackages('/theme'));
+    }
+
+    public function testReturnsNullOnInvalidJsonOutput(): void
     {
         $this->shell->method('execute')->willReturn('npm ERR! something went wrong');
 
-        $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
+        $this->assertNull($this->packageManager->getOutdatedPackages('/theme'));
     }
 
-    public function testReturnsEmptyListWhenShellExecutionFails(): void
+    public function testReturnsNullOnNpmErrorJsonOutput(): void
+    {
+        $this->shell->method('execute')->willReturn(json_encode([
+            'error' => ['code' => 'ENOTFOUND', 'summary' => 'registry unreachable'],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->assertNull($this->packageManager->getOutdatedPackages('/theme'));
+    }
+
+    public function testReturnsNullWhenShellExecutionFails(): void
     {
         $this->shell->method('execute')->willThrowException(new \RuntimeException('npm not found'));
 
-        $this->assertSame([], $this->packageManager->getOutdatedPackages('/theme'));
+        $this->assertNull($this->packageManager->getOutdatedPackages('/theme'));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #204 

This pull request introduces a new CLI command for updating Node.js dependencies of Magento themes and improves documentation and workflow coverage for this feature. The main changes include the implementation of the `mageforge:dependencies:update` command, comprehensive documentation for its usage and behavior, and integration into the compatibility workflow.

**New CLI Command for Dependency Updates:**

* Added `mageforge:dependencies:update` command (`src/Console/Command/Dependencies/UpdateCommand.php`) to update Node.js dependencies for one or more themes, supporting interactive and non-interactive usage, wildcards, dry-run, and updating to latest versions.
* Introduced `DependencyUpdateResult` enum to standardize the result of dependency update operations (`src/Service/DependencyUpdateResult.php`).

**Documentation Updates:**

* Updated `docs/commands_reference.md` to add the new command to the overview table, provide a detailed reference section, and include it in the quick list of commands. [[1]](diffhunk://#diff-b6a59c290091e3371c84540128f61623ec057aab8b6ea35917a115400aff1055L8-R14) [[2]](diffhunk://#diff-b6a59c290091e3371c84540128f61623ec057aab8b6ea35917a115400aff1055R128-R162) [[3]](diffhunk://#diff-b6a59c290091e3371c84540128f61623ec057aab8b6ea35917a115400aff1055R249)

**Workflow Enhancements:**

* Extended `.github/workflows/magento-compatibility.yml` to test the new command and its alias, ensuring coverage in CI. [[1]](diffhunk://#diff-e4d2e5901ca4112dba62fc88b0d80176fe856ba318e15b75a55b13cb6ae9a9ccR150) [[2]](diffhunk://#diff-e4d2e5901ca4112dba62fc88b0d80176fe856ba318e15b75a55b13cb6ae9a9ccR166)
* Annotated GitHub Actions steps with version comments for clarity and maintainability.