### PR TITLE
fix: update export-ignore rules in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,8 @@
 /.release-please-manifest.json    export-ignore
 /skills-lock.json                 export-ignore
 /.trunkignore                     export-ignore
+/tests/                           export-ignore
+/phpunit.xml.dist                 export-ignore
+/infection.json5                  export-ignore
+/.gitignore                       export-ignore
+/.gitattributes                   export-ignore

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -81,9 +81,11 @@ jobs:
           composer update --with-dependencies
           bin/magento setup:upgrade
 
-          # phpstan.neon is export-ignored, so the copied path repository omits
-          # it; place it next to the analysed source for the phpstan job.
+          # phpstan.neon and tests/ are export-ignored, so the copied path
+          # repository omits them; place them next to the analysed source so the
+          # phpstan job can analyse both `src` and `tests` (per phpstan.neon).
           cp ../mageforge/phpstan.neon vendor/openforgeproject/mageforge/phpstan.neon
+          cp -r ../mageforge/tests vendor/openforgeproject/mageforge/tests
 
       - name: Pack Magento install
         run: |


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to exclude several test and configuration files from export operations, helping to keep package exports clean and focused on production code.

Export ignore rules:

* Added `export-ignore` for the `/tests/` directory, `phpunit.xml.dist`, `infection.json5`, `.gitignore`, and `.gitattributes` to prevent these files from being included in exported archives.