### PR TITLE
fix: use correct SHA for peter-evans/create-pull-request v8.1.0

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff2fa2e423999752927 # v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "chore: upgrade trunk linters"
           title: "chore: upgrade trunk linters"


### PR DESCRIPTION
The previous SHA 98357b1...752927 was truncated (invalid, did not exist in the repo), causing 'Unable to resolve action' failures in the workflow. Use the correct SHA c0f553f...d2ece0 for v8.1.0. Verified with pinact run --check against the GitHub API.